### PR TITLE
feat: improve search_sorted_cache functionality, refactor cache files

### DIFF
--- a/inc/frontend_cache.h
+++ b/inc/frontend_cache.h
@@ -7,6 +7,7 @@
 void* search_fast_cache(size_t size);
 void* search_cache(size_t size, int page_type);
 void* search_sorted_cache(size_t size, int page_type);
+void* search_unsorted_cache(size_t size);
 
 // =================== Print Cache ===================
 void print_fast_cache(t_tiny_chunk** fast_cache);

--- a/inc/frontend_cache.h
+++ b/inc/frontend_cache.h
@@ -3,12 +3,19 @@
 
 #include "types.h"
 
+// =================== Search Cache ===================
 void* search_fast_cache(size_t size);
 void* search_cache(size_t size, int page_type);
+void* search_sorted_cache(size_t size, int page_type);
+
+// =================== Print Cache ===================
 void print_fast_cache(t_tiny_chunk** fast_cache);
+
+// =================== Create Cache ===================
 t_cache* create_frontend_cache(t_pagemap* pagemap);
 t_tiny_chunk** create_fast_cache(t_cache* cache);
 
+// =================== Cache Table ===================
 cache_table* cache_table_create(t_cache* cache);
 void cache_table_destroy(cache_table* table);
 void* cache_table_get(cache_table* table, const char* key);

--- a/src/frontend_cache/cache.c
+++ b/src/frontend_cache/cache.c
@@ -17,32 +17,6 @@ t_cache* create_frontend_cache(t_pagemap* pagemap) {
     return cache;
 }
 
-t_tiny_chunk** create_fast_cache(t_cache* cache) {
-    t_tiny_chunk** fast_cache = (t_tiny_chunk**)CACHE_SHIFT(cache);
-
-    // printf("fast_cache pointer: %p\n", fast_cache);
-    for (size_t i = 0; i < cache->fcache_size; ++i) {
-        fast_cache[i] = NULL;
-    }
-
-    // void* last_byte = (void*)MEMORY_SHIFT(cache, (cache->fcache_size * sizeof(t_tiny_chunk*)));
-    // printf("fast_cache end: %p\n", last_byte);
-    return fast_cache;
-}
-
-void* search_unsorted_cache(size_t size) {
-    t_chunk* unsorted_cache = g_pagemap->frontend_cache->unsorted_cache;
-    while (unsorted_cache) {
-        printf("unsorted_cache->size: %zu\n", unsorted_cache->size);
-        if (unsorted_cache->size >= size) {
-            return unsorted_cache;
-        }
-        unsorted_cache = unsorted_cache->fd;
-    }
-
-    return NULL;
-}
-
 void* search_cache(size_t size, int page_type) {
     void* ptr = NULL;
 

--- a/src/frontend_cache/fast_cache.c
+++ b/src/frontend_cache/fast_cache.c
@@ -1,0 +1,52 @@
+#include "../../inc/main.h"
+
+void* search_fast_cache(size_t size) {
+  int index = get_fpage_index(size);
+  t_tiny_chunk** f_cache = g_pagemap->frontend_cache->fast_cache;
+  t_fpage* fpage = NULL;
+  t_tiny_chunk* tiny;
+
+  if (f_cache[index]) {
+    // allocate top chunk in link list and replace
+    tiny = f_cache[index];
+    f_cache[index] = f_cache[index]->next;
+  }
+  else {
+    // split off new chunk
+    // TODO check logic
+    fpage = g_pagemap->span_head->fastpages;
+    while (index > 0) {
+      fpage = fpage->next;
+      index--;
+    }
+    tiny = create_tiny_chunk(fpage);
+  }
+
+  return (void*)MEMORY_SHIFT(tiny, TINY_CHUNK_OVERHEAD);
+}
+
+
+void print_fast_cache(t_tiny_chunk** fast_cache) {
+  t_tiny_chunk* temp;
+  int count;
+  int min_align;
+
+  count = (min_chunk_size == 8) ? 8 : 7;
+  min_align = (count == 8) ? 1 : 2;
+
+  for (int i = 0; i < count; i++) {
+    temp = fast_cache[i];
+    if (temp) {
+      while (temp) {
+        log_info("tiny chunk");
+        printf("size = %d\n", (i + min_align) * 8);
+        print_tiny_chunk(temp);
+        temp = temp->next;
+      }
+    }
+    else {
+      printf("fast_cache[%i] = NULL\n", i);
+    }
+
+  }
+}

--- a/src/frontend_cache/fast_cache.c
+++ b/src/frontend_cache/fast_cache.c
@@ -1,5 +1,18 @@
 #include "../../inc/main.h"
 
+t_tiny_chunk** create_fast_cache(t_cache* cache) {
+  t_tiny_chunk** fast_cache = (t_tiny_chunk**)CACHE_SHIFT(cache);
+
+  // printf("fast_cache pointer: %p\n", fast_cache);
+  for (size_t i = 0; i < cache->fcache_size; ++i) {
+    fast_cache[i] = NULL;
+  }
+
+  // void* last_byte = (void*)MEMORY_SHIFT(cache, (cache->fcache_size * sizeof(t_tiny_chunk*)));
+  // printf("fast_cache end: %p\n", last_byte);
+  return fast_cache;
+}
+
 void* search_fast_cache(size_t size) {
   int index = get_fpage_index(size);
   t_tiny_chunk** f_cache = g_pagemap->frontend_cache->fast_cache;
@@ -24,7 +37,6 @@ void* search_fast_cache(size_t size) {
 
   return (void*)MEMORY_SHIFT(tiny, TINY_CHUNK_OVERHEAD);
 }
-
 
 void print_fast_cache(t_tiny_chunk** fast_cache) {
   t_tiny_chunk* temp;

--- a/src/frontend_cache/sorted_cache.c
+++ b/src/frontend_cache/sorted_cache.c
@@ -1,0 +1,54 @@
+#include "../../inc/main.h"
+
+t_page* get_page_head(int page_type) {
+  t_page* page_head = g_pagemap->span_head->page_head;
+  if (page_type == 3) {
+    while ((int)page_head->pagetype != page_type) {
+      page_head = page_head->next;
+    }
+    page_head = g_pagemap->span_head->page_head;
+  }
+  return page_head;
+}
+
+t_chunk* get_top_chunk(t_page* page) {
+  t_chunk* top_chunk = page->top_chunk;
+  while (IS_IN_USE(top_chunk)) {
+    top_chunk = top_chunk->fd;
+  }
+
+  if (top_chunk == NULL) {
+    t_chunk* new_chunk = create_top_chunk(page);
+    top_chunk->fd = new_chunk;
+    new_chunk->bk = top_chunk;
+    top_chunk = new_chunk;
+  }
+
+  return top_chunk;
+}
+
+void* search_sorted_cache(size_t size, int page_type) {
+  // TODO: determine how to get correct bin_size
+  char key[32];
+  snprintf(key, sizeof(key), "%zu", size);
+
+  cache_table* cache_table = g_pagemap->frontend_cache->cache_table;
+
+  void* ptr = NULL;
+
+  if ((ptr = cache_table_get(cache_table, key)) != NULL) {
+    return (void*)MEMORY_SHIFT(ptr, sizeof(t_chunk));
+  }
+
+  t_page* page_head = get_page_head(page_type);
+
+  t_chunk* top_chunk = get_top_chunk(page_head);
+
+  if ((cache_table_set(cache_table, key, top_chunk)) != NULL) {
+    SET_IN_USE(top_chunk);
+    return (void*)MEMORY_SHIFT(cache_table_get(cache_table, key), sizeof(t_chunk));
+  }
+
+  printf("Returning NULL\n");
+  return NULL;
+}

--- a/src/frontend_cache/sorted_cache.c
+++ b/src/frontend_cache/sorted_cache.c
@@ -1,5 +1,19 @@
 #include "../../inc/main.h"
 
+// TODO: maybe move to unsorted_cache if this gets too big
+void* search_unsorted_cache(size_t size) {
+  t_chunk* unsorted_cache = g_pagemap->frontend_cache->unsorted_cache;
+  while (unsorted_cache) {
+    printf("unsorted_cache->size: %zu\n", unsorted_cache->size);
+    if (unsorted_cache->size >= size) {
+      return unsorted_cache;
+    }
+    unsorted_cache = unsorted_cache->fd;
+  }
+
+  return NULL;
+}
+
 t_page* get_page_head(int page_type) {
   t_page* page_head = g_pagemap->span_head->page_head;
   if (page_type == 3) {


### PR DESCRIPTION
### What was done?

- moved a few methods into separate cache files to reduce file sizes and improve organization. We now have a `fast_cache.c` and `sorted_cache.c`
- improved `search_sorted_cache` implementation

### :tophat: Instructions