### PR TITLE
Beki/revert

### DIFF
--- a/JSMalloc_diagrams.md
+++ b/JSMalloc_diagrams.md
@@ -238,7 +238,7 @@ Next, we implement the functions to free a chunk, write a boundary tag, and coal
 ### Function to Write Boundary Tag
 
 ```c
-void write_boundary_tag(chunk* ch) {
+void chunk_write_boundary_tag(chunk* ch) {
     size_t* boundary_tag = (size_t*)((char*)ch + CHUNK_SIZE(ch) - sizeof(size_t));
     *boundary_tag = ch->size;
 }
@@ -247,7 +247,7 @@ void write_boundary_tag(chunk* ch) {
 ### Function to Free a Chunk and Coalesce if Possible
 
 ```c
-void free_chunk(chunk* ch) {
+void chunk_free(chunk* ch) {
     chunk* next_chunk = NEXT_CHUNK(ch);
 
     // Coalesce with next chunk if it's free
@@ -257,7 +257,7 @@ void free_chunk(chunk* ch) {
     }
 
     // Write the boundary tag
-    write_boundary_tag(ch);
+    chunk_write_boundary_tag(ch);
 
     // Coalesce with previous chunk if it's free
     if (!(ch->prev_size & 1)) { // Check if previous chunk is free
@@ -266,7 +266,7 @@ void free_chunk(chunk* ch) {
         ch = prev_chunk;
 
         // Write the boundary tag
-        write_boundary_tag(ch);
+        chunk_write_boundary_tag(ch);
     }
 
     // Insert chunk into the free list (simplified for this example)
@@ -295,7 +295,7 @@ int main() {
 
     // Simulate freeing the chunk
     ch->size &= ~1; // Mark as free
-    free_chunk(ch);
+    chunk_free(ch);
 
     // For demonstration purposes, print the size
 ```

--- a/inc/backend_heap.h
+++ b/inc/backend_heap.h
@@ -15,7 +15,7 @@ t_fpage* create_fpage(t_fpage* prev_page, int page_count,
         
 void create_pages(t_pagemap* pagemap, t_span* span);
 t_page* create_base_page(t_pagemap* pagemap, t_span* span);
-t_page* create_page(t_page* prev_page, t_span* span, int pagetype);
+t_page* create_page(t_page* prev_page, int pagetype);
 void destroy_active_page(t_page* page);
 void destroy_page(t_page* page);
 

--- a/inc/backend_heap.h
+++ b/inc/backend_heap.h
@@ -3,19 +3,19 @@
 
 #include "types.h"
 
-t_span* create_base_span(t_cache* cache);
-t_span* add_span(t_pagemap* pagemap, size_t size);
-void create_pagemap(t_pagemap** pagemap);
-void destroy_pagemap(t_pagemap* pagemap);
+t_span* span_base_create(t_cache* cache);
+t_span* span_add(t_pagemap* pagemap, size_t size);
+void pagemap_create(t_pagemap** pagemap);
+void pagemap_destroy(t_pagemap* pagemap);
 
-void create_fpages(t_pagemap* pagemap);
-t_fpage* create_base_fpage(t_pagemap* pagemap);
-t_fpage* create_fpage(t_fpage* prev_page, int page_count,
+void fpages_create(t_pagemap* pagemap);
+t_fpage* fpage_base_create(t_pagemap* pagemap);
+t_fpage* fpage_create(t_fpage* prev_page, int page_count,
         size_t chunk_size, t_cache* cache);
         
-void create_pages(t_pagemap* pagemap, t_span* span);
-t_page* create_base_page(t_pagemap* pagemap, t_span* span);
-t_page* create_page(t_page* prev_page, int pagetype);
+void pages_create(t_pagemap* pagemap, t_span* span);
+t_page* page_base_create(t_pagemap* pagemap, t_span* span);
+t_page* page_create(t_page* prev_page, int pagetype);
 void destroy_active_page(t_page* page);
 void destroy_page(t_page* page);
 

--- a/inc/chunks.h
+++ b/inc/chunks.h
@@ -4,14 +4,14 @@
 #include "types.h"
 
 void chunk_write_boundary_tag(t_chunk* chunk);
-t_chunk* chunk_top_create(t_page* page);
+t_chunk* chunk_base_create(void* start, size_t size);
 t_chunk* chunk_split(t_chunk* chunk, size_t size);
 t_chunk* chunk_merge(t_chunk* value_1, t_chunk* value_2);
 t_chunk* try_merge(t_chunk* value);
 void chunk_free(void* ptr, size_t size);
 
 void tiny_chunk_print(t_tiny_chunk* tiny);
-t_tiny_chunk* tiny_chunk_top_create(t_fpage* page);
+t_tiny_chunk* tiny_chunk_base_create(t_fpage* page);
 t_tiny_chunk* tiny_chunk_create(t_fpage* fpage);
 void tiny_chunk_free(void* ptr, size_t size);
 

--- a/inc/chunks.h
+++ b/inc/chunks.h
@@ -3,19 +3,20 @@
 
 #include "types.h"
 
-void write_boundary_tag(t_chunk* chunk);
-t_chunk* create_top_chunk(t_page* page);
-t_chunk* split_chunk(t_chunk* chunk, size_t size);
-void free_chunk(void* ptr, size_t size);
-
-void print_tiny_chunk(t_tiny_chunk* tiny);
-t_tiny_chunk* create_top_tiny_chunk(t_fpage* page);
-t_tiny_chunk* create_tiny_chunk(t_fpage* fpage);
-void free_tiny_chunk(void* ptr, size_t size);
-void free_huge_chunk(void* ptr, size_t size);
-t_chunk* allocate_huge_chunk(size_t size);
-void free_huge_chunk(void* ptr, size_t size);
-t_chunk* merge_chunks(t_chunk* value_1, t_chunk* value_2);
+void chunk_write_boundary_tag(t_chunk* chunk);
+t_chunk* chunk_top_create(t_page* page);
+t_chunk* chunk_split(t_chunk* chunk, size_t size);
+t_chunk* chunk_merge(t_chunk* value_1, t_chunk* value_2);
 t_chunk* try_merge(t_chunk* value);
+void chunk_free(void* ptr, size_t size);
+
+void tiny_chunk_print(t_tiny_chunk* tiny);
+t_tiny_chunk* tiny_chunk_top_create(t_fpage* page);
+t_tiny_chunk* tiny_chunk_create(t_fpage* fpage);
+void tiny_chunk_free(void* ptr, size_t size);
+
+t_chunk* huge_chunk_allocate(size_t size);
+void huge_chunk_free(void* ptr, size_t size);
+
 
 #endif

--- a/inc/constants.h
+++ b/inc/constants.h
@@ -29,7 +29,7 @@ extern t_pagemap* g_pagemap;
 // Helper macros to access boundary tags
 #define CHUNK_OVERHEAD (sizeof(size_t) * 2)
 #define NEXT_CHUNK(chunk) ((t_chunk*)((char*)(chunk) + CHUNK_SIZE(chunk)))
-#define PREV_SIZE(chunk) ((size_t)((char*)(chunk) - CHUNK_OVERHEAD))
+#define PREV_SIZE(chunk) ((size_t)((char*)(chunk) - sizeof(size_t)))
 #define PREV_CHUNK(chunk, prev_size) ((t_chunk*)((char*)(chunk) - prev_size))
 #define TINY_CHUNK_OVERHEAD sizeof(size_t)
 

--- a/inc/constants.h
+++ b/inc/constants.h
@@ -24,12 +24,14 @@ extern t_pagemap* g_pagemap;
 
 // Helper macros to set and check t_chunk size
 #define SIZE_MASK (~0x1)  // Mask with all bits set except the least significant bit
-#define CHUNK_SIZE(t_chunk) ((t_chunk)->size & SIZE_MASK) // Mask out least significant bit
+#define CHUNK_SIZE(chunk) ((chunk)->size & SIZE_MASK) // Mask out least significant bit
+#define DATA_TO_CHUNK(ptr) ((t_chunk*)((char*)(ptr) - sizeof(size_t)))
+#define CHUNK_TO_DATA(chunk) (void*)((char *)(chunk) + sizeof(size_t))
 
 // Helper macros to access boundary tags
 #define CHUNK_OVERHEAD (sizeof(size_t) * 2)
 #define NEXT_CHUNK(chunk) ((t_chunk*)((char*)(chunk) + CHUNK_SIZE(chunk)))
-#define PREV_SIZE(chunk) ((size_t)((char*)(chunk) - sizeof(size_t)))
+#define PREV_SIZE(chunk) (*(size_t*)((char*)(chunk) - sizeof(size_t)))
 #define PREV_CHUNK(chunk, prev_size) ((t_chunk*)((char*)(chunk) - prev_size))
 #define TINY_CHUNK_OVERHEAD sizeof(size_t)
 

--- a/inc/frontend_cache.h
+++ b/inc/frontend_cache.h
@@ -10,11 +10,11 @@ void* search_sorted_cache(size_t size, int page_type);
 void* search_unsorted_cache(size_t size);
 
 // =================== Print Cache ===================
-void print_fast_cache(t_tiny_chunk** fast_cache);
+void fast_cache_print(t_tiny_chunk** fast_cache);
 
 // =================== Create Cache ===================
-t_cache* create_frontend_cache(t_pagemap* pagemap);
-t_tiny_chunk** create_fast_cache(t_cache* cache);
+t_cache* frontend_cache_create(t_pagemap* pagemap);
+t_tiny_chunk** fast_cache_create(t_cache* cache);
 
 // =================== Cache Table ===================
 t_cache_table* cache_table_create(t_cache* cache);

--- a/inc/tests.h
+++ b/inc/tests.h
@@ -9,7 +9,7 @@
 
 
 // =================== Chunk ===================
-void chunk_top_create_test(void** state);
+void chunk_base_create_test(void** state);
 void chunk_split_test_success(void** state);
 void chunk_split_test_failure(void** state);
 void huge_chunk_allocate_test_success(void** state);
@@ -20,7 +20,7 @@ void chunk_merge_test(void** state);
 void try_merge_is_in_use_test(void** state);
 
 // =================== Tiny Chunk ===================
-void tiny_chunk_top_create_test(void** state);
+void tiny_chunk_base_create_test(void** state);
 void tiny_chunk_create_test(void** state);
 void tiny_chunk_free_test(void** state);
 

--- a/inc/tests.h
+++ b/inc/tests.h
@@ -1,11 +1,11 @@
+#ifndef TESTS_H_
+#define TESTS_H_
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
 #include "main.h"
-
-#ifndef TESTS_H_
-#define TESTS_H_
 
 
 // =================== Chunk ===================
@@ -28,6 +28,11 @@ void free_tiny_chunk_test(void** state);
 // =================== Fast Cache ===================
 void create_fast_cache_test(void** state);
 void search_fast_cache_test(void** state);
+
+// =================== Cache Table ===================
+void cache_table_create_test(void** state);
+void cache_table_set_test(void** state);
+void cache_table_get_test(void** state);
 
 // =================== Unsorted Cache ===================
 void search_unsorted_cache_test(void** state);

--- a/inc/tests.h
+++ b/inc/tests.h
@@ -9,35 +9,33 @@
 
 
 // =================== Chunk ===================
-void create_top_chunk_test(void** state);
-void split_chunk_test_success(void** state);
-void split_chunk_test_failure(void** state);
-void allocate_huge_chunk_test_success(void** state);
-void allocate_huge_chunk_test_failure(void** state);
-void free_chunk_test(void** state);
-void free_huge_chunk_test(void** state);
-void merge_chunks_test(void** state);
+void chunk_top_create_test(void** state);
+void chunk_split_test_success(void** state);
+void chunk_split_test_failure(void** state);
+void huge_chunk_allocate_test_success(void** state);
+void huge_chunk_allocate_test_failure(void** state);
+void chunk_free_test(void** state);
+void huge_chunk_free_test(void** state);
+void chunk_merge_test(void** state);
 void try_merge_is_in_use_test(void** state);
 
 // =================== Tiny Chunk ===================
-void create_top_tiny_chunk_test(void** state);
-void create_tiny_chunk_test(void** state);
-void free_tiny_chunk_test(void** state);
+void tiny_chunk_top_create_test(void** state);
+void tiny_chunk_create_test(void** state);
+void tiny_chunk_free_test(void** state);
 
 
 // =================== Fast Cache ===================
-void create_fast_cache_test(void** state);
+void fast_cache_create_test(void** state);
 void search_fast_cache_test(void** state);
 
 // =================== Cache Table ===================
 void cache_table_create_test(void** state);
-void cache_table_set_test(void** state);
-void cache_table_get_test(void** state);
+void cache_table_set_and_get_test(void** state);
 
 // =================== Unsorted Cache ===================
 void search_unsorted_cache_test(void** state);
 void search_unsorted_cache_null_test(void** state);
 void search_unsorted_cache_large_test(void** state);
-void search_unsorted_cache_small_test(void** state);
 
 #endif

--- a/inc/tests.h
+++ b/inc/tests.h
@@ -38,4 +38,9 @@ void search_unsorted_cache_test(void** state);
 void search_unsorted_cache_null_test(void** state);
 void search_unsorted_cache_large_test(void** state);
 
+// =================== Sorted Cache ===================
+void search_sorted_cache_test(void** state);
+void search_sorted_cache_null_test(void** state);
+// void search_sorted_cache_large_test(void** state);
+
 #endif

--- a/inc/types.h
+++ b/inc/types.h
@@ -49,11 +49,9 @@ typedef struct s_fpage t_fpage;
 
 struct s_page {
     t_page* next;
-    t_page* prev;
-    size_t pagetype;
-    size_t memory;
-    size_t chunk_count;
     t_chunk* base_chunk;
+    size_t mem_size;
+    size_t pagetype;
 };
 
 struct s_fpage {

--- a/inc/types.h
+++ b/inc/types.h
@@ -53,7 +53,7 @@ struct s_page {
     size_t pagetype;
     size_t memory;
     size_t chunk_count;
-    t_chunk* top_chunk;
+    t_chunk* base_chunk;
 };
 
 struct s_fpage {

--- a/inc/utils.h
+++ b/inc/utils.h
@@ -6,7 +6,9 @@
 #define UNUSED(x) (void)(x)
 
 void log_info(const char* message);
+void log_error(const char *error);
 void log_heap();
+void custom_exit(const char *error);
 
 void system_settings();
 void check_system_pointer();

--- a/src/backend_heap/fpage.c
+++ b/src/backend_heap/fpage.c
@@ -1,9 +1,9 @@
 #include "../../inc/main.h"
 
 
-void create_fpages(t_pagemap* pagemap) {
+void fpages_create(t_pagemap* pagemap) {
   int count = 0;
-  pagemap->span_head->fastpages = create_base_fpage(pagemap);
+  pagemap->span_head->fastpages = fpage_base_create(pagemap);
   count += 1;
 
   t_cache* cache = pagemap->frontend_cache;
@@ -13,7 +13,7 @@ void create_fpages(t_pagemap* pagemap) {
   if (chunk_size == 8) chunk_size += 8;
 
   while (count < FAST_PAGE_ALLOCATION_SIZE && chunk_size <= 64) {
-    temp = create_fpage(current, count, chunk_size, cache);
+    temp = fpage_create(current, count, chunk_size, cache);
     current->next = temp;
     current = temp;
     chunk_size += 8;
@@ -21,7 +21,7 @@ void create_fpages(t_pagemap* pagemap) {
   }
 }
 
-t_fpage* create_base_fpage(t_pagemap* pagemap) {
+t_fpage* fpage_base_create(t_pagemap* pagemap) {
   /* Beginning pointer for fastpages is found by starting at the start of
   the pageheap and using MEMORY_SHIFT to add the standard pages total
   allocation size. */
@@ -34,7 +34,7 @@ t_fpage* create_base_fpage(t_pagemap* pagemap) {
   fpage->memory = PAGE_SIZE - sizeof(t_fpage);
   fpage->chunk_size = min_chunk_size;
   fpage->max_chunks = fpage->memory / fpage->chunk_size;
-  fpage->last_chunk = create_top_tiny_chunk(fpage);
+  fpage->last_chunk = tiny_chunk_top_create(fpage);
 
   /* The tiny_chunk is immediately added to the fast_cache. */
   pagemap->frontend_cache->fast_cache[0] = fpage->last_chunk;
@@ -42,7 +42,7 @@ t_fpage* create_base_fpage(t_pagemap* pagemap) {
   return fpage;
 }
 
-t_fpage* create_fpage(t_fpage* prev_page, int count,
+t_fpage* fpage_create(t_fpage* prev_page, int count,
         size_t chunk_size, t_cache* cache) {
   t_fpage* fpage = (t_fpage*)MEMORY_SHIFT(FASTPAGE_SHIFT(prev_page), prev_page->memory);
   fpage->chunk_count = 1;
@@ -50,7 +50,7 @@ t_fpage* create_fpage(t_fpage* prev_page, int count,
   fpage->memory = PAGE_SIZE - sizeof(t_fpage);
   fpage->chunk_size = chunk_size;
   fpage->max_chunks = fpage->memory / fpage->chunk_size;
-  fpage->last_chunk = create_top_tiny_chunk(fpage);
+  fpage->last_chunk = tiny_chunk_top_create(fpage);
 
   /* The tiny_chunk is immediately added to the fast_cache.
   Logic takes into account 2 pages for size 16 bytes when the

--- a/src/backend_heap/fpage.c
+++ b/src/backend_heap/fpage.c
@@ -27,6 +27,7 @@ t_fpage* create_base_fpage(t_pagemap* pagemap) {
   allocation size. */
   size_t pages_area = PAGE_SIZE *
     (SMALL_PAGE_ALLOCATION_SIZE + LARGE_PAGE_ALLOCATION_SIZE);
+
   t_fpage* fpage = (t_fpage*)MEMORY_SHIFT(pagemap, pages_area);
   fpage->chunk_count = 1;
   fpage->next = NULL;
@@ -34,6 +35,7 @@ t_fpage* create_base_fpage(t_pagemap* pagemap) {
   fpage->chunk_size = min_chunk_size;
   fpage->max_chunks = fpage->memory / fpage->chunk_size;
   fpage->last_chunk = create_top_tiny_chunk(fpage);
+
   /* The tiny_chunk is immediately added to the fast_cache. */
   pagemap->frontend_cache->fast_cache[0] = fpage->last_chunk;
 
@@ -62,5 +64,6 @@ t_fpage* create_fpage(t_fpage* prev_page, int count,
   else {
     cache->fast_cache[count] = fpage->last_chunk;
   }
+  
   return fpage;
 }

--- a/src/backend_heap/fpage.c
+++ b/src/backend_heap/fpage.c
@@ -34,7 +34,7 @@ t_fpage* fpage_base_create(t_pagemap* pagemap) {
   fpage->memory = PAGE_SIZE - sizeof(t_fpage);
   fpage->chunk_size = min_chunk_size;
   fpage->max_chunks = fpage->memory / fpage->chunk_size;
-  fpage->last_chunk = tiny_chunk_top_create(fpage);
+  fpage->last_chunk = tiny_chunk_base_create(fpage);
 
   /* The tiny_chunk is immediately added to the fast_cache. */
   pagemap->frontend_cache->fast_cache[0] = fpage->last_chunk;
@@ -50,7 +50,7 @@ t_fpage* fpage_create(t_fpage* prev_page, int count,
   fpage->memory = PAGE_SIZE - sizeof(t_fpage);
   fpage->chunk_size = chunk_size;
   fpage->max_chunks = fpage->memory / fpage->chunk_size;
-  fpage->last_chunk = tiny_chunk_top_create(fpage);
+  fpage->last_chunk = tiny_chunk_base_create(fpage);
 
   /* The tiny_chunk is immediately added to the fast_cache.
   Logic takes into account 2 pages for size 16 bytes when the

--- a/src/backend_heap/page.c
+++ b/src/backend_heap/page.c
@@ -43,7 +43,6 @@ t_page* page_base_create(t_pagemap* pagemap, t_span* span) {
     page->memory = PAGE_SIZE - sizeof(t_span) - sizeof(t_page);
   }
 
-  page->pagetype = small;
   chunk_top_create(page);
 
   return page;

--- a/src/backend_heap/page.c
+++ b/src/backend_heap/page.c
@@ -1,17 +1,17 @@
 #include "../../inc/main.h"
 
 
-void create_pages(t_pagemap* pagemap, t_span* span) {
+void pages_create(t_pagemap* pagemap, t_span* span) {
   int pages_left = SMALL_PAGE_ALLOCATION_SIZE;
   t_page* current = NULL;
   t_page* temp = NULL;
-  span->page_head = create_base_page(pagemap, span);
+  span->page_head = page_base_create(pagemap, span);
   pages_left -= 1;
   current = span->page_head;
 
   while (pages_left > 0) {
     temp = current;
-    current = create_page(current, small);
+    current = page_create(current, small);
     temp->next = current;
     pages_left -= 1;
   }
@@ -19,13 +19,13 @@ void create_pages(t_pagemap* pagemap, t_span* span) {
   pages_left = LARGE_PAGE_ALLOCATION_SIZE;
   while (pages_left > 0) {
     temp = current;
-    current = create_page(current, large);
+    current = page_create(current, large);
     temp->next = current;
     pages_left -= 1;
   }
 }
 
-t_page* create_base_page(t_pagemap* pagemap, t_span* span) {
+t_page* page_base_create(t_pagemap* pagemap, t_span* span) {
   t_cache* cache = pagemap->frontend_cache;
   t_page* page = (t_page*)SPAN_SHIFT(span);
   page->chunk_count = 1;
@@ -44,19 +44,19 @@ t_page* create_base_page(t_pagemap* pagemap, t_span* span) {
   }
 
   page->pagetype = small;
-  create_top_chunk(page);
+  chunk_top_create(page);
 
   return page;
 }
 
-t_page* create_page(t_page* prev_page, int pagetype) {
+t_page* page_create(t_page* prev_page, int pagetype) {
   t_page* page = (t_page*)MEMORY_SHIFT(PAGE_SHIFT(prev_page), prev_page->memory);
   page->chunk_count = 1;
   page->prev = prev_page;
   page->next = NULL;
   page->memory = PAGE_SIZE - sizeof(t_page);
   page->pagetype = pagetype;
-  create_top_chunk(page);
+  chunk_top_create(page);
 
   return page;
 }

--- a/src/backend_heap/page.c
+++ b/src/backend_heap/page.c
@@ -4,18 +4,23 @@
 void create_pages(t_pagemap* pagemap, t_span* span) {
   int pages_left = SMALL_PAGE_ALLOCATION_SIZE;
   t_page* current = NULL;
+  t_page* temp = NULL;
   span->page_head = create_base_page(pagemap, span);
   pages_left -= 1;
   current = span->page_head;
 
   while (pages_left > 0) {
+    temp = current;
     current = create_page(current, small);
+    temp->next = current;
     pages_left -= 1;
   }
 
   pages_left = LARGE_PAGE_ALLOCATION_SIZE;
   while (pages_left > 0) {
+    temp = current;
     current = create_page(current, large);
+    temp->next = current;
     pages_left -= 1;
   }
 }

--- a/src/backend_heap/page.c
+++ b/src/backend_heap/page.c
@@ -9,13 +9,13 @@ void create_pages(t_pagemap* pagemap, t_span* span) {
   current = span->page_head;
 
   while (pages_left > 0) {
-    current = create_page(current, span, small);
+    current = create_page(current, small);
     pages_left -= 1;
   }
 
   pages_left = LARGE_PAGE_ALLOCATION_SIZE;
   while (pages_left > 0) {
-    current = create_page(current, span, large);
+    current = create_page(current, large);
     pages_left -= 1;
   }
 }
@@ -44,8 +44,7 @@ t_page* create_base_page(t_pagemap* pagemap, t_span* span) {
   return page;
 }
 
-t_page* create_page(t_page* prev_page, t_span* span, int pagetype) {
-  UNUSED(span);
+t_page* create_page(t_page* prev_page, int pagetype) {
   t_page* page = (t_page*)MEMORY_SHIFT(PAGE_SHIFT(prev_page), prev_page->memory);
   page->chunk_count = 1;
   page->prev = prev_page;

--- a/src/backend_heap/pagemap.c
+++ b/src/backend_heap/pagemap.c
@@ -67,19 +67,7 @@ destroy_active_page() will be used in a future optimization. It will allow us
 to return individual pages to the OS if the program running my_malloc is using
 lower amounts of memory space.
 */
-// void destroy_active_page(t_page* page) {
-//     if (page->next && page->prev) {
-//         page->next->prev = page->prev;
-//         page->prev->next = page->next;
-//     }
-//     else if (page->next) {
-//         page->next->prev = NULL;
-//     }
-//     else {
-//         page->prev->next = NULL;
-//     }
-//     if (munmap(page, PAGE_SIZE) == -1) custom_exit("munmap error");
-// }
+// void destroy_active_page(t_page* page) {}
 
 void destroy_page(t_page* page) {
     if (munmap(page, PAGE_SIZE) == -1) custom_exit("munmap error");

--- a/src/backend_heap/pagemap.c
+++ b/src/backend_heap/pagemap.c
@@ -18,7 +18,7 @@ void pagemap_create(t_pagemap** pagemap) {
     (*pagemap)->span_head = span_base_create((*pagemap)->frontend_cache);
     (*pagemap)->total_pages = BASE_HEAP_SIZE / PAGE_SIZE;
     pages_create(*pagemap, (*pagemap)->span_head);
-    (*pagemap)->top_chunk = (*pagemap)->span_head->page_head->top_chunk;
+    (*pagemap)->top_chunk = (*pagemap)->span_head->page_head->base_chunk;
     (*pagemap)->last_chunk = NULL;
     fpages_create(*pagemap);
 }
@@ -67,19 +67,19 @@ destroy_active_page() will be used in a future optimization. It will allow us
 to return individual pages to the OS if the program running my_malloc is using
 lower amounts of memory space.
 */
-void destroy_active_page(t_page* page) {
-    if (page->next && page->prev) {
-        page->next->prev = page->prev;
-        page->prev->next = page->next;
-    }
-    else if (page->next) {
-        page->next->prev = NULL;
-    }
-    else {
-        page->prev->next = NULL;
-    }
-    if (munmap(page, PAGE_SIZE) == -1) custom_exit("munmap error");
-}
+// void destroy_active_page(t_page* page) {
+//     if (page->next && page->prev) {
+//         page->next->prev = page->prev;
+//         page->prev->next = page->next;
+//     }
+//     else if (page->next) {
+//         page->next->prev = NULL;
+//     }
+//     else {
+//         page->prev->next = NULL;
+//     }
+//     if (munmap(page, PAGE_SIZE) == -1) custom_exit("munmap error");
+// }
 
 void destroy_page(t_page* page) {
     if (munmap(page, PAGE_SIZE) == -1) custom_exit("munmap error");

--- a/src/chunks/chunk.c
+++ b/src/chunks/chunk.c
@@ -7,14 +7,13 @@ void chunk_write_boundary_tag(t_chunk* chunk) {
     // printf("&boundary_tag = %zu\n", *boundary_tag);
 }
 
-t_chunk* chunk_top_create(t_page* page) {
-    t_chunk* chunk = (t_chunk*)PAGE_SHIFT(page);
-    chunk->size = page->memory;
+t_chunk* chunk_base_create(void* start, size_t size) {
+    t_chunk* chunk = (t_chunk*)PAGE_SHIFT(start);
+    chunk->size = size;
     SET_FREE(chunk);
     chunk_write_boundary_tag(chunk);
     chunk->fd = NULL;
     chunk->bk = NULL;
-    page->base_chunk = chunk;
 
     return chunk;
 }

--- a/src/chunks/chunk.c
+++ b/src/chunks/chunk.c
@@ -98,7 +98,7 @@ t_chunk* chunk_merge(t_chunk* value_1, t_chunk* value_2) {
 
 t_chunk* try_merge(t_chunk* value) {
     // coalescing algo
-    // TODO find out if chunk is first chunk in page or rearrange pageheaders
+    // TODO trouble shoot boundary tag reading
     int flag = 0;
 
     t_chunk* next = NEXT_CHUNK(value);
@@ -138,7 +138,9 @@ void chunk_free(void* ptr, size_t size) {
     value->size = size;
     SET_FREE(value);
 
-    value = try_merge(value);
+    /* merge aka coalescing chunk system not yet working
+    TODO: V3 implementation of merge */
+    // value = try_merge(value);
     if (g_pagemap->frontend_cache->unsorted_cache == NULL) {
         g_pagemap->frontend_cache->unsorted_cache = value;
         return;

--- a/src/chunks/chunk.c
+++ b/src/chunks/chunk.c
@@ -94,21 +94,16 @@ t_chunk* chunk_merge(t_chunk* value_1, t_chunk* value_2) {
 
 t_chunk* try_merge(t_chunk* value) {
     // coalescing algo
-    // find out if chunk is first chunk in page or rearrange pageheaders
+    // TODO find out if chunk is first chunk in page or rearrange pageheaders
     int flag = 0;
     t_chunk* prev = PREV_CHUNK(value, PREV_SIZE(value));
-    if (prev) {
-        printf("prev->size: %zu\n", prev->size);
-        printf("prev pointer: %p\n", prev);
+    if (prev && prev->size && prev->size > 64) {
         if (!IS_IN_USE(prev)) flag += 1;
     }
     t_chunk* next = NEXT_CHUNK(value);
-    if (next) {
+    if (next && next->size && next->size > 64) {
         if (!IS_IN_USE(next)) flag += 2;
-        printf("next->size: %zu\n", next->size);
-        printf("next pointer: %p\n", next);
     }
-
 
     switch (flag) {
     case 1: return chunk_merge(prev, value);

--- a/src/chunks/chunk.c
+++ b/src/chunks/chunk.c
@@ -13,7 +13,7 @@ t_chunk* chunk_top_create(t_page* page) {
     chunk_write_boundary_tag(chunk);
     chunk->fd = NULL;
     chunk->bk = NULL;
-    page->top_chunk = chunk;
+    page->base_chunk = chunk;
 
     return chunk;
 }

--- a/src/chunks/chunk.c
+++ b/src/chunks/chunk.c
@@ -20,7 +20,7 @@ t_chunk* create_top_chunk(t_page* page) {
 
 // input parameters are t_chunk *chunk and size_t chunk_size
 t_chunk* split_chunk(t_chunk* chunk, size_t size) {
-    if (CHUNK_SIZE(chunk) <= size) {
+    if (CHUNK_SIZE(chunk) <= (size + 72)) {
         fprintf(stderr, "Invalid split size: %zu (chunk size: %zu)\n", size, chunk->size);
         custom_exit("Error in split_chunk()\n");
     }
@@ -29,7 +29,11 @@ t_chunk* split_chunk(t_chunk* chunk, size_t size) {
     t_chunk* temp = chunk->fd;
     size_t initial_chunk_size = chunk->size;
 
-    // WHAT HAPPENS TO THIS CHUNK? it is returned for use
+    int flag = 0;
+
+    if (g_pagemap->top_chunk == chunk) flag = 1;
+    else if (g_pagemap->last_chunk == chunk) flag = 2;
+
     // Update the original chunk's size, free status, next pointer & boundary_tag
     t_chunk* first_chunk = chunk;
     first_chunk->size = size;
@@ -46,13 +50,23 @@ t_chunk* split_chunk(t_chunk* chunk, size_t size) {
     second_chunk->fd = temp;
     write_boundary_tag(second_chunk);
 
-    if (cache_table_set(second_chunk))  // add second_chunk to cache_table
-        custom_exit("Unable to add chunk to cache_table in split_chunk()\n");
-
+    if (flag == 1) g_pagemap->top_chunk = second_chunk;
+    else if (flag == 2) g_pagemap->last_chunk = second_chunk;
+    else {
+        second_chunk->fd = g_pagemap->frontend_cache->unsorted_cache;
+        g_pagemap->frontend_cache->unsorted_cache = second_chunk;
+    }
+        
     return first_chunk;
 }
 
+
 t_chunk* allocate_huge_chunk(size_t size) {
+    if (size < (size_t)PAGE_SIZE) {
+        log_error("Error: allocation size too small.\n");
+        return NULL;
+    }
+
     // Allocate a huge chunk
     t_chunk* huge_chunk = (t_chunk*)mmap(NULL, size, PROT_READ | 
                 PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -72,24 +86,13 @@ t_chunk* merge_chunks(t_chunk* value_1, t_chunk* value_2) {
     if (value_2->bk) value_2->bk->fd = value_2->fd;
     if (value_2->fd) value_2->fd->bk = value_2->bk;
 
-    printf("value_1->size before merge: %zu\n", value_1->size);
     value_1->size += value_2->size;
-    printf("value_1->size after merge: %zu\n", value_1->size);
     write_boundary_tag(value_1);
 
     return value_1;
 }
 
 t_chunk* try_merge(t_chunk* value) {
-    if (IS_IN_USE(value)) {
-        printf("chunk is in use\n");
-        return value;
-    }
-    if (value->fd == NULL && value->bk == NULL) {
-        printf("chunk list is empty\n");
-        printf("value->size: %zu\n", value->size);
-        return value;
-    }
     // coalescing algo
     int flag = 0;
     printf("value->size: %zu\n", value->size);
@@ -98,14 +101,18 @@ t_chunk* try_merge(t_chunk* value) {
     printf("value->bk: %p\n", value->bk);
     printf("is_in_use: %lu\n", IS_IN_USE(value));
     t_chunk* prev = PREV_CHUNK(value, PREV_SIZE(value));
-    printf("prev->size: %zu\n", prev->size);
-    printf("prev pointer: %p\n", prev);
+    if (prev) {
+        printf("prev->size: %zu\n", prev->size);
+        printf("prev pointer: %p\n", prev);
+        if (!IS_IN_USE(prev)) flag += 1;
+    }
     t_chunk* next = NEXT_CHUNK(value);
-    printf("next->size: %zu\n", next->size);
-    printf("next pointer: %p\n", next);
+    if (next) {
+        if (!IS_IN_USE(next)) flag += 2;
+        printf("next->size: %zu\n", next->size);
+        printf("next pointer: %p\n", next);
+    }
 
-    if (!IS_IN_USE(prev)) flag += 1;
-    if (!IS_IN_USE(next)) flag += 2;
 
     switch (flag) {
     case 1: return merge_chunks(prev, value);

--- a/src/chunks/tiny_chunk.c
+++ b/src/chunks/tiny_chunk.c
@@ -6,7 +6,7 @@ void tiny_chunk_print(t_tiny_chunk* tiny) {
     if (tiny->next) printf("next t_tiny_chunk = %p\n", tiny->next);
 }
 
-t_tiny_chunk* tiny_chunk_top_create(t_fpage* page) {
+t_tiny_chunk* tiny_chunk_base_create(t_fpage* page) {
     t_tiny_chunk* tiny = (t_tiny_chunk*)FASTPAGE_SHIFT(page);
     tiny->size = page->chunk_size;
     tiny->next = NULL;

--- a/src/chunks/tiny_chunk.c
+++ b/src/chunks/tiny_chunk.c
@@ -1,12 +1,12 @@
 #include "../../inc/main.h" 
 
 
-void print_tiny_chunk(t_tiny_chunk* tiny) {
+void tiny_chunk_print(t_tiny_chunk* tiny) {
     printf("t_tiny_chunk pointer = %p\n", tiny);
     if (tiny->next) printf("next t_tiny_chunk = %p\n", tiny->next);
 }
 
-t_tiny_chunk* create_top_tiny_chunk(t_fpage* page) {
+t_tiny_chunk* tiny_chunk_top_create(t_fpage* page) {
     t_tiny_chunk* tiny = (t_tiny_chunk*)FASTPAGE_SHIFT(page);
     tiny->size = page->chunk_size;
     tiny->next = NULL;
@@ -14,7 +14,7 @@ t_tiny_chunk* create_top_tiny_chunk(t_fpage* page) {
     return tiny;
 }
 
-t_tiny_chunk* create_tiny_chunk(t_fpage* fpage) {
+t_tiny_chunk* tiny_chunk_create(t_fpage* fpage) {
     t_tiny_chunk* tiny;
     tiny = (t_tiny_chunk*)MEMORY_SHIFT(fpage->last_chunk, fpage->chunk_size);
     fpage->chunk_count += 1;
@@ -24,7 +24,7 @@ t_tiny_chunk* create_tiny_chunk(t_fpage* fpage) {
     return tiny;
 }
 
-void free_tiny_chunk(void* ptr, size_t size) {
+void tiny_chunk_free(void* ptr, size_t size) {
     t_tiny_chunk** f_cache = g_pagemap->frontend_cache->fast_cache;
 
     int index = get_fpage_index(size);

--- a/src/chunks/tiny_chunk.c
+++ b/src/chunks/tiny_chunk.c
@@ -17,10 +17,17 @@ t_tiny_chunk* create_top_tiny_chunk(t_fpage* page) {
 t_tiny_chunk* create_tiny_chunk(t_fpage* fpage) {
     t_tiny_chunk* tiny;
     tiny = (t_tiny_chunk*)MEMORY_SHIFT(fpage->last_chunk, fpage->chunk_size);
+
+    log_info("create_tiny_chunk()");
+    printf("fpage->chunk_count: %zu\n", fpage->chunk_count);
+    printf("fpage->last_chunk: %p\n", fpage->last_chunk);
+
     fpage->chunk_count += 1;
     fpage->last_chunk = tiny;
-    // TODO: log to double check that chunk_count and last_chunk are being assigned properly
 
+    printf("fpage->chunk_count: %zu\n", fpage->chunk_count);
+    printf("fpage->last_chunk: %p\n", fpage->last_chunk);
+    
     tiny->next = NULL;
 
     return tiny;

--- a/src/chunks/tiny_chunk.c
+++ b/src/chunks/tiny_chunk.c
@@ -17,17 +17,8 @@ t_tiny_chunk* create_top_tiny_chunk(t_fpage* page) {
 t_tiny_chunk* create_tiny_chunk(t_fpage* fpage) {
     t_tiny_chunk* tiny;
     tiny = (t_tiny_chunk*)MEMORY_SHIFT(fpage->last_chunk, fpage->chunk_size);
-
-    log_info("create_tiny_chunk()");
-    printf("fpage->chunk_count: %zu\n", fpage->chunk_count);
-    printf("fpage->last_chunk: %p\n", fpage->last_chunk);
-
     fpage->chunk_count += 1;
     fpage->last_chunk = tiny;
-
-    printf("fpage->chunk_count: %zu\n", fpage->chunk_count);
-    printf("fpage->last_chunk: %p\n", fpage->last_chunk);
-    
     tiny->next = NULL;
 
     return tiny;

--- a/src/frontend_cache/cache.c
+++ b/src/frontend_cache/cache.c
@@ -2,13 +2,13 @@
 #include "../../inc/main.h"
 
 
-t_cache* create_frontend_cache(t_pagemap* pagemap) {
+t_cache* frontend_cache_create(t_pagemap* pagemap) {
     t_cache* cache = (t_cache*)PAGEMAP_SHIFT(pagemap);
 
     if (min_chunk_size == 8) cache->fcache_size = 8;
     else cache->fcache_size = 7;
 
-    cache->fast_cache = create_fast_cache(cache);
+    cache->fast_cache = fast_cache_create(cache);
     cache->cache_table = cache_table_create(cache);
     cache->unsorted_cache = NULL;
 

--- a/src/frontend_cache/cache_table.c
+++ b/src/frontend_cache/cache_table.c
@@ -36,8 +36,9 @@ t_chunk* cache_table_get(size_t size) {
   t_cache_table* ct = g_pagemap->frontend_cache->cache_table;
   size_t index = cache_table_index(ct, size);
 
-  if (!ct->entries[index].value) {
-    return NULL;
+  while (!ct->entries[index].value && index < ct->capacity) {
+    index++;
+    if (index == ct->capacity - 1) return NULL;
   }
 
   t_chunk* value = ct->entries[index].value;
@@ -53,19 +54,19 @@ static int cache_table_set_entry(t_chunk* value) {
   size_t index = cache_table_index(ct, value->size);
 
   // Loop till we find an empty entry.
-  while (ct->entries[index].key != NULL) {
+  if (ct->entries[index].key != NULL) {
     if (strcmp(key, ct->entries[index].key) == 0) {
-      // Found key (it already exists), add value to head, update pointers.
+      // Found key (it already exists)
+      // If bin is empty, add t_chunk to .value
+      if (!ct->entries[index].value) {
+        ct->entries[index].value = value;
+        return EXIT_SUCCESS;
+      }
+      // If bin is NOT empty, add value to head, update pointers.
       value->fd = ct->entries[index].value;
       ct->entries[index].value->bk = value;
       ct->entries[index].value = value;
       return EXIT_SUCCESS;
-    }
-    // Key wasn't in this slot, move to next (linear probing).
-    index++;
-    if (index >= ct->capacity) {
-      // At end of entries array, wrap around.
-      index = 0;
     }
   }
 

--- a/src/frontend_cache/cache_table.c
+++ b/src/frontend_cache/cache_table.c
@@ -2,12 +2,12 @@
 
 
 t_cache_table* cache_table_create(t_cache* cache) {
-  /* The next line shifts the starting point of the t_cache_table struct 
-  beyond fastcache. */
+  /* Shift starting point of t_cache_table struct beyond fastcache. */
   t_cache_table* table = (t_cache_table*)MEMORY_SHIFT(cache, 
-      (cache->fcache_size * sizeof(t_tiny_chunk)));    
+                        (cache->fcache_size * sizeof(t_tiny_chunk)));
   table->capacity = NUM_BINS;
-  table->entries = (cache_table_entry*)MEMORY_SHIFT(table, sizeof(t_cache_table));
+  table->entries = (cache_table_entry*)MEMORY_SHIFT(table, 
+                  sizeof(t_cache_table));
 
   return table;
 }

--- a/src/frontend_cache/fast_cache.c
+++ b/src/frontend_cache/fast_cache.c
@@ -16,20 +16,25 @@ void* search_fast_cache(size_t size) {
   t_tiny_chunk** f_cache = g_pagemap->frontend_cache->fast_cache;
   t_fpage* fpage = NULL;
   t_tiny_chunk* tiny;
+  log_info("search_fast_cache()");
 
   if (f_cache[index]) {
     // allocate top chunk in link list and replace
+    printf("f_cache[index]: %p\n", f_cache[index]);
     tiny = f_cache[index];
     f_cache[index] = f_cache[index]->next;
+    if (f_cache[index]) printf("f_cache[index]: %p\n", f_cache[index]);
+    else printf("f_cache[index] is NULL\n");
   }
   else {
     // split off new chunk
-    // TODO check logic
     fpage = g_pagemap->span_head->fastpages;
     while (index > 0) {
       fpage = fpage->next;
       index--;
     }
+    printf("creating new t_tiny_chunk:\nsize: %zu, fpage->size %zu\n", 
+        size, fpage->chunk_size);
     tiny = create_tiny_chunk(fpage);
   }
 

--- a/src/frontend_cache/fast_cache.c
+++ b/src/frontend_cache/fast_cache.c
@@ -1,6 +1,6 @@
 #include "../../inc/main.h"
 
-t_tiny_chunk** create_fast_cache(t_cache* cache) {
+t_tiny_chunk** fast_cache_create(t_cache* cache) {
   t_tiny_chunk** fast_cache = (t_tiny_chunk**)CACHE_SHIFT(cache);
 
   for (size_t i = 0; i < cache->fcache_size; ++i) {
@@ -34,13 +34,13 @@ void* search_fast_cache(size_t size) {
       index--;
     }
     // printf("creating new t_tiny_chunk:\nsize: %zu, fpage->size %zu\n", size, fpage->chunk_size);
-    tiny = create_tiny_chunk(fpage);
+    tiny = tiny_chunk_create(fpage);
   }
 
   return (void*)MEMORY_SHIFT(tiny, TINY_CHUNK_OVERHEAD);
 }
 
-void print_fast_cache(t_tiny_chunk** fast_cache) {
+void fast_cache_print(t_tiny_chunk** fast_cache) {
   t_tiny_chunk* temp;
   int count;
   int min_align;
@@ -54,7 +54,7 @@ void print_fast_cache(t_tiny_chunk** fast_cache) {
       while (temp) {
         log_info("tiny chunk");
         printf("size = %d\n", (i + min_align) * 8);
-        print_tiny_chunk(temp);
+        tiny_chunk_print(temp);
         temp = temp->next;
       }
     }

--- a/src/frontend_cache/fast_cache.c
+++ b/src/frontend_cache/fast_cache.c
@@ -16,25 +16,24 @@ void* search_fast_cache(size_t size) {
   t_tiny_chunk** f_cache = g_pagemap->frontend_cache->fast_cache;
   t_fpage* fpage = NULL;
   t_tiny_chunk* tiny;
-  log_info("search_fast_cache()");
+  // log_info("search_fast_cache()");
 
   if (f_cache[index]) {
     // allocate top chunk in link list and replace
-    printf("f_cache[index]: %p\n", f_cache[index]);
+    // printf("f_cache[index]: %p\n", f_cache[index]);
     tiny = f_cache[index];
     f_cache[index] = f_cache[index]->next;
-    if (f_cache[index]) printf("f_cache[index]: %p\n", f_cache[index]);
-    else printf("f_cache[index] is NULL\n");
+    // if (f_cache[index]) printf("f_cache[index]: %p\n", f_cache[index]);
+    // else printf("f_cache[index] is NULL\n");
   }
   else {
     // split off new chunk
     fpage = g_pagemap->span_head->fastpages;
-    while (index > 0) {
+    while (index >= 0) {
       fpage = fpage->next;
       index--;
     }
-    printf("creating new t_tiny_chunk:\nsize: %zu, fpage->size %zu\n", 
-        size, fpage->chunk_size);
+    // printf("creating new t_tiny_chunk:\nsize: %zu, fpage->size %zu\n", size, fpage->chunk_size);
     tiny = create_tiny_chunk(fpage);
   }
 

--- a/src/frontend_cache/sorted_cache.c
+++ b/src/frontend_cache/sorted_cache.c
@@ -15,7 +15,7 @@ void* search_unsorted_cache(size_t size) {
       // printf("found unsorted_chunk %p, size: %zu\n", unsorted_chunk, unsorted_chunk->size);
       if (unsorted_chunk->size > size + 72) {
         g_pagemap->frontend_cache->unsorted_cache = unsorted_chunk->fd;
-        new = split_chunk(unsorted_chunk, size);
+        new = chunk_split(unsorted_chunk, size);
       }
       // printf("here\n");
       return (void*)MEMORY_SHIFT(new, CHUNK_OVERHEAD);
@@ -33,7 +33,7 @@ void* search_unsorted_cache(size_t size) {
 search_sorted_cache() checks to see if there are any t_chunks in the
 corresponding cache_table bin by calling cache_table_get(). If the t_chunk is
 found a void* to the data field is returned.
-If no t_chunk is found, split_chunk is called and creates a new t_chunk from
+If no t_chunk is found, chunk_split is called and creates a new t_chunk from
 t_pagemap* g_pagemap->top_chunk.
 */
 void* search_sorted_cache(size_t size, int page_type) {
@@ -45,7 +45,7 @@ void* search_sorted_cache(size_t size, int page_type) {
   }
 
   // TODO: add last_chunk logic
-  if ((ptr = split_chunk(g_pagemap->top_chunk, size)) != NULL) {
+  if ((ptr = chunk_split(g_pagemap->top_chunk, size)) != NULL) {
     printf("split top_chunk\n");
     return (void*)MEMORY_SHIFT(ptr, sizeof(t_chunk));
   }

--- a/src/frontend_cache/sorted_cache.c
+++ b/src/frontend_cache/sorted_cache.c
@@ -38,16 +38,20 @@ t_pagemap* g_pagemap->top_chunk.
 */
 void* search_sorted_cache(size_t size, int page_type) {
   UNUSED(page_type);
-  void* ptr = NULL;
+  t_chunk* ck = NULL;
 
-  if ((ptr = cache_table_get(size)) != NULL) {
-    return (void*)MEMORY_SHIFT(ptr, sizeof(t_chunk));
+  if ((ck = cache_table_get(size)) != NULL) {
+    // split chunk if too large
+    if (ck->size > size + 72) {
+      ck = chunk_split(ck, size);
+      return CHUNK_TO_DATA(ck);
+    }
+    return CHUNK_TO_DATA(ck);
   }
 
   // TODO: add last_chunk logic
-  if ((ptr = chunk_split(g_pagemap->top_chunk, size)) != NULL) {
-    printf("split top_chunk\n");
-    return (void*)MEMORY_SHIFT(ptr, sizeof(t_chunk));
+  if ((ck = chunk_split(g_pagemap->top_chunk, size)) != NULL) {
+    return CHUNK_TO_DATA(ck);
   }
 
   printf("Returning NULL\n");

--- a/src/frontend_cache/sorted_cache.c
+++ b/src/frontend_cache/sorted_cache.c
@@ -8,14 +8,17 @@ split or a void* to the data field is returned.
 */
 void* search_unsorted_cache(size_t size) {
   t_chunk* unsorted_chunk = g_pagemap->frontend_cache->unsorted_cache;
+  t_chunk* new = NULL;
 
   while (unsorted_chunk) {
     if (unsorted_chunk->size >= size) {
+      // printf("found unsorted_chunk %p, size: %zu\n", unsorted_chunk, unsorted_chunk->size);
       if (unsorted_chunk->size > size + 72) {
-        unsorted_chunk = split_chunk(unsorted_chunk, size);
+        g_pagemap->frontend_cache->unsorted_cache = unsorted_chunk->fd;
+        new = split_chunk(unsorted_chunk, size);
       }
-      g_pagemap->frontend_cache->unsorted_cache = unsorted_chunk->fd;
-      return (void*)MEMORY_SHIFT(unsorted_chunk, CHUNK_OVERHEAD);
+      // printf("here\n");
+      return (void*)MEMORY_SHIFT(new, CHUNK_OVERHEAD);
     }
     else {
       cache_table_set(unsorted_chunk);

--- a/src/main.c
+++ b/src/main.c
@@ -20,11 +20,11 @@ size_t pointer_size = 0;
 #ifndef TESTING
 int main() {
     system_settings();
-    create_pagemap(&g_pagemap);
+    pagemap_create(&g_pagemap);
 
     void* ptr = my_malloc(100);
     printf("ptr: %p\n", ptr);
-    destroy_pagemap(g_pagemap);
+    pagemap_destroy(g_pagemap);
 
     return 0;
 }

--- a/src/my_free.c
+++ b/src/my_free.c
@@ -12,12 +12,12 @@ void my_free(void* ptr) {
     int page_type = get_page_type(size);
 
     switch (page_type) {
-    case 1: free_tiny_chunk(ptr, size);
+    case 1: tiny_chunk_free(ptr, size);
             break;
     case 2:
-    case 3: free_chunk(ptr, size);
+    case 3: chunk_free(ptr, size);
             break;
-    case 4: free_huge_chunk(ptr, size);
+    case 4: huge_chunk_free(ptr, size);
             break;
     default: printf("Error reading memory size: Can not free.\n");
             break;

--- a/src/my_malloc.c
+++ b/src/my_malloc.c
@@ -4,7 +4,7 @@
 void* my_malloc(size_t size) {
     if (g_pagemap == NULL) {
         system_settings();
-        create_pagemap(&g_pagemap);
+        pagemap_create(&g_pagemap);
     }
 
     // get category & search heap
@@ -22,7 +22,7 @@ void* search_heap(size_t size, int page_type) {
     case 1: return search_fast_cache(size);
     case 2:
     case 3: return search_cache(size, page_type);
-    case 4: return allocate_huge_chunk(size);
+    case 4: return huge_chunk_allocate(size);
     default: break;
     }
 

--- a/src/my_realloc.c
+++ b/src/my_realloc.c
@@ -13,7 +13,6 @@ void* my_realloc(void* ptr, size_t size) {
     void* new_ptr = my_malloc(size);
 
     if (new_ptr != NULL) {
-        // TODO: make sure cast works
         my_strcpy((char*)new_ptr, (char*)ptr);
         my_free(ptr);
         return new_ptr;

--- a/src/utils.c
+++ b/src/utils.c
@@ -21,15 +21,6 @@ void log_heap() {
     void* last_byte = (void*)MEMORY_SHIFT(g_pagemap, BASE_HEAP_SIZE);
     printf("pageheap end: %p\n", last_byte);
 
-  // printf("fpage pointer: %p\n", fpage);
-  // printf("sizeof(t_fpage): %zu\n", sizeof(t_fpage));
-  // printf("available memory: %zu\n", fpage->memory);
-  // printf("chunk size: %zu\n", fpage->chunk_size);
-  // printf("maximum number of chunks: %zu\n", fpage->max_chunks);
-  // void* last_byte = (void*)MEMORY_SHIFT(fpage, fpage->memory + sizeof(t_fpage));
-  // printf("fpage end = %p\n", last_byte);
-  // log_info("frontend cache");
-
     log_info("span");
     printf("span pointer: %p\n", g_pagemap->span_head);
     last_byte = (void*)MEMORY_SHIFT(g_pagemap->span_head, sizeof(t_span));

--- a/src/utils.c
+++ b/src/utils.c
@@ -127,23 +127,6 @@ t_page* get_page_head(int page_type) {
   return page_head;
 }
 
-t_chunk* get_top_chunk(t_page* page) {
-  t_chunk* top_chunk = page->top_chunk;
-
-  while (IS_IN_USE(top_chunk)) {
-    top_chunk = top_chunk->fd;
-  }
-
-  if (top_chunk == NULL) {
-    t_chunk* new_chunk = chunk_top_create(page);
-    top_chunk->fd = new_chunk;
-    new_chunk->bk = top_chunk;
-    top_chunk = new_chunk;
-  }
-
-  return top_chunk;
-}
-
 
 char* my_strcpy(char* dst, char* src) {
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -135,7 +135,7 @@ t_chunk* get_top_chunk(t_page* page) {
   }
 
   if (top_chunk == NULL) {
-    t_chunk* new_chunk = create_top_chunk(page);
+    t_chunk* new_chunk = chunk_top_create(page);
     top_chunk->fd = new_chunk;
     new_chunk->bk = top_chunk;
     top_chunk = new_chunk;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,8 @@
-#include "../inc/main.h"
+/* For testing comment out line 4 and line 41.
+For use uncomment lines 4/41, comment out lines 5 and 42 */
 
+// #include "../inc/main.h"
+#include "../inc/tests.h"
 
 void log_info(const char* message) {
     printf("\n=====%s=====\n", message);
@@ -35,7 +38,8 @@ void log_heap() {
 
 void custom_exit(const char *error) {
     log_error(error);
-    exit(EXIT_FAILURE);
+    // exit(EXIT_FAILURE);
+    function_called();
 }
 
 /*

--- a/tests/chunks/chunk_test.c
+++ b/tests/chunks/chunk_test.c
@@ -9,24 +9,24 @@ void chunk_top_create_test(void** state) {
   assert_false(IS_IN_USE(top_chunk));
   assert_null(top_chunk->fd);
   assert_null(top_chunk->bk);
-  assert_ptr_equal(page->top_chunk, top_chunk);
+  assert_ptr_equal(page->base_chunk, top_chunk);
 }
 
 void chunk_split_test_success(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
 
-  t_chunk* split = chunk_split(pagemap->span_head->page_head->top_chunk, 100);
+  size_t new_top_size = pagemap->top_chunk->size - 100;
+  t_chunk* split = chunk_split(pagemap->top_chunk, 100);
   assert_int_equal(CHUNK_SIZE(split), 100);
-  assert_int_equal(CHUNK_SIZE(pagemap->span_head->page_head->top_chunk), CHUNK_SIZE(split));
-  assert_int_equal(pagemap->span_head->page_head->top_chunk->fd, split->fd);
+  assert_int_equal(pagemap->top_chunk->fd, split->fd);
   assert_int_equal(split->fd, NULL);
-  assert_int_equal(pagemap->span_head->page_head->top_chunk->bk, NULL);
-  assert_int_equal(split, pagemap->span_head->page_head->top_chunk);
+  assert_int_equal(split->bk, NULL);
+  assert_int_equal(new_top_size, pagemap->top_chunk->size);
 }
 
 void chunk_split_test_failure(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
-  t_chunk* top_chunk = pagemap->span_head->page_head->top_chunk;
+  t_chunk* top_chunk = pagemap->top_chunk;
   size_t size = CHUNK_SIZE(top_chunk);
   expect_function_call(custom_exit);
 
@@ -54,10 +54,10 @@ void huge_chunk_allocate_test_failure(void** state) {
 void chunk_free_test(void** state) {
   UNUSED(state);
 
-  //   t_pagemap* pagemap = (t_pagemap*)*state;
-  //   t_chunk* chunk = pagemap->span_head->page_head->top_chunk;
-  //   size_t size = CHUNK_SIZE(chunk);
-  //   chunk_free(chunk, size);
+  // t_pagemap* pagemap = (t_pagemap*)*state;
+  // t_chunk* chunk = pagemap->top_chunk;
+  // size_t size = CHUNK_SIZE(chunk);
+  // chunk_free(chunk, size);
 }
 
 void huge_chunk_free_test(void** state) {

--- a/tests/chunks/chunk_test.c
+++ b/tests/chunks/chunk_test.c
@@ -24,15 +24,6 @@ void chunk_split_test_success(void** state) {
   assert_int_equal(new_top_size, pagemap->top_chunk->size);
 }
 
-void chunk_split_test_failure(void** state) {
-  t_pagemap* pagemap = (t_pagemap*)*state;
-  t_chunk* top_chunk = pagemap->top_chunk;
-  size_t size = CHUNK_SIZE(top_chunk);
-  expect_function_call(custom_exit);
-
-  chunk_split(top_chunk, size + 1);
-}
-
 
 void huge_chunk_allocate_test_success(void** state) {
   UNUSED(state);
@@ -96,8 +87,16 @@ void try_merge_is_in_use_test(void** state) {
   t_chunk* top_chunk = pagemap->top_chunk;
   t_chunk* chunk1 = chunk_split(top_chunk, 72);
   top_chunk = pagemap->top_chunk;
+  t_chunk* chunk2 = chunk_split(top_chunk, 100);
+  top_chunk = pagemap->top_chunk;
+  t_chunk* chunk3 = chunk_split(top_chunk, 72);
+  top_chunk = pagemap->top_chunk;
+  t_chunk* chunk4 = chunk_split(top_chunk, 72);
   SET_FREE(chunk1);
+  SET_FREE(chunk2);
+  SET_FREE(chunk3);
+  SET_FREE(chunk4);
 
-  t_chunk* merged_chunk = try_merge(chunk1);
+  t_chunk* merged_chunk = try_merge(chunk3);
   assert_ptr_equal(merged_chunk, chunk1);
 }

--- a/tests/chunks/chunk_test.c
+++ b/tests/chunks/chunk_test.c
@@ -1,15 +1,16 @@
 #include "../../inc/tests.h"
 
 
-void chunk_top_create_test(void** state) {
+void chunk_base_create_test(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
-  t_page* page = pagemap->span_head->page_head;
-  t_chunk* top_chunk = chunk_top_create(page);
-  assert_int_equal(top_chunk->size, page->memory);
-  assert_false(IS_IN_USE(top_chunk));
-  assert_null(top_chunk->fd);
-  assert_null(top_chunk->bk);
-  assert_ptr_equal(page->base_chunk, top_chunk);
+  t_page* page = pagemap->span_head->page_head->next;
+  size_t mem_size = PAGE_SIZE - sizeof(t_page);
+  t_chunk* chunk = page->base_chunk;
+  assert_int_equal(mem_size, chunk->size);
+  assert_false(IS_IN_USE(chunk));
+  assert_null(chunk->fd);
+  assert_null(chunk->bk);
+  assert_ptr_equal(page->base_chunk, chunk);
 }
 
 void chunk_split_test_success(void** state) {

--- a/tests/chunks/chunk_test.c
+++ b/tests/chunks/chunk_test.c
@@ -1,10 +1,10 @@
 #include "../../inc/tests.h"
 
 
-void create_top_chunk_test(void** state) {
+void chunk_top_create_test(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_page* page = pagemap->span_head->page_head;
-  t_chunk* top_chunk = create_top_chunk(page);
+  t_chunk* top_chunk = chunk_top_create(page);
   assert_int_equal(top_chunk->size, page->memory);
   assert_false(IS_IN_USE(top_chunk));
   assert_null(top_chunk->fd);
@@ -12,10 +12,10 @@ void create_top_chunk_test(void** state) {
   assert_ptr_equal(page->top_chunk, top_chunk);
 }
 
-void split_chunk_test_success(void** state) {
+void chunk_split_test_success(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
 
-  t_chunk* split = split_chunk(pagemap->span_head->page_head->top_chunk, 100);
+  t_chunk* split = chunk_split(pagemap->span_head->page_head->top_chunk, 100);
   assert_int_equal(CHUNK_SIZE(split), 100);
   assert_int_equal(CHUNK_SIZE(pagemap->span_head->page_head->top_chunk), CHUNK_SIZE(split));
   assert_int_equal(pagemap->span_head->page_head->top_chunk->fd, split->fd);
@@ -24,60 +24,60 @@ void split_chunk_test_success(void** state) {
   assert_int_equal(split, pagemap->span_head->page_head->top_chunk);
 }
 
-void split_chunk_test_failure(void** state) {
+void chunk_split_test_failure(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_chunk* top_chunk = pagemap->span_head->page_head->top_chunk;
   size_t size = CHUNK_SIZE(top_chunk);
   expect_function_call(custom_exit);
 
-  split_chunk(top_chunk, size + 1);
+  chunk_split(top_chunk, size + 1);
 }
 
 
-void allocate_huge_chunk_test_success(void** state) {
+void huge_chunk_allocate_test_success(void** state) {
   UNUSED(state);
 
   size_t size = 4096;
-  t_chunk* huge_chunk = allocate_huge_chunk(size);
+  t_chunk* huge_chunk = huge_chunk_allocate(size);
   assert_int_equal(huge_chunk->size, size);
 }
 
-void allocate_huge_chunk_test_failure(void** state) {
+void huge_chunk_allocate_test_failure(void** state) {
   UNUSED(state);
 
   size_t size = 0;
-  t_chunk* huge_chunk = allocate_huge_chunk(size);
+  t_chunk* huge_chunk = huge_chunk_allocate(size);
   assert_null(huge_chunk);
 }
 
 // TODO: Implement this test
-void free_chunk_test(void** state) {
+void chunk_free_test(void** state) {
   UNUSED(state);
 
   //   t_pagemap* pagemap = (t_pagemap*)*state;
   //   t_chunk* chunk = pagemap->span_head->page_head->top_chunk;
   //   size_t size = CHUNK_SIZE(chunk);
-  //   free_chunk(chunk, size);
+  //   chunk_free(chunk, size);
 }
 
-void free_huge_chunk_test(void** state) {
+void huge_chunk_free_test(void** state) {
   UNUSED(state);
   size_t size = 4096;
-  t_chunk* huge_chunk = allocate_huge_chunk(size);
-  free_huge_chunk(huge_chunk, size);
+  t_chunk* huge_chunk = huge_chunk_allocate(size);
+  huge_chunk_free(huge_chunk, size);
 }
 
 
-void merge_chunks_test(void** state) {
+void chunk_merge_test(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_chunk* top_chunk = pagemap->top_chunk;
-  t_chunk* chunk1 = split_chunk(top_chunk, 72);
+  t_chunk* chunk1 = chunk_split(top_chunk, 72);
   top_chunk = pagemap->top_chunk;
-  t_chunk* chunk2 = split_chunk(top_chunk, 100);
+  t_chunk* chunk2 = chunk_split(top_chunk, 100);
   SET_FREE(chunk1);
   SET_FREE(chunk2);
   size_t merge_size = chunk1->size + chunk2->size;
-  t_chunk* merged_chunk = merge_chunks(chunk1, chunk2);
+  t_chunk* merged_chunk = chunk_merge(chunk1, chunk2);
 
   assert_int_equal(merged_chunk->size, merge_size);
   assert_int_equal(merged_chunk->size, chunk1->size);
@@ -94,7 +94,7 @@ void merge_chunks_test(void** state) {
 void try_merge_is_in_use_test(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_chunk* top_chunk = pagemap->top_chunk;
-  t_chunk* chunk1 = split_chunk(top_chunk, 72);
+  t_chunk* chunk1 = chunk_split(top_chunk, 72);
   top_chunk = pagemap->top_chunk;
   SET_FREE(chunk1);
 

--- a/tests/chunks/chunk_test.c
+++ b/tests/chunks/chunk_test.c
@@ -83,20 +83,34 @@ void chunk_merge_test(void** state) {
 }
 
 void try_merge_is_in_use_test(void** state) {
+  UNUSED(state);
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_chunk* top_chunk = pagemap->top_chunk;
-  t_chunk* chunk1 = chunk_split(top_chunk, 72);
+  size_t size = round_up_to_next(72);
+  t_chunk* chunk1 = chunk_split(top_chunk, size);
   top_chunk = pagemap->top_chunk;
-  t_chunk* chunk2 = chunk_split(top_chunk, 100);
-  top_chunk = pagemap->top_chunk;
-  t_chunk* chunk3 = chunk_split(top_chunk, 72);
-  top_chunk = pagemap->top_chunk;
-  t_chunk* chunk4 = chunk_split(top_chunk, 72);
   SET_FREE(chunk1);
-  SET_FREE(chunk2);
-  SET_FREE(chunk3);
-  SET_FREE(chunk4);
+  cache_table_set(chunk1);
 
-  t_chunk* merged_chunk = try_merge(chunk3);
+  top_chunk = pagemap->top_chunk;
+  size = round_up_to_next(100);
+  t_chunk* chunk2 = chunk_split(top_chunk, size);
+  SET_FREE(chunk2);
+  cache_table_set(chunk2);
+  
+  top_chunk = pagemap->top_chunk;
+  size = round_up_to_next(212);
+  t_chunk* chunk3 = chunk_split(top_chunk, size);
+  SET_FREE(chunk3);
+  cache_table_set(chunk3);
+
+  t_chunk* merged_chunk = try_merge(chunk2);
+  assert_ptr_equal(merged_chunk, chunk2);
+  printf("**After merge** chunk2->size: %zu\n", chunk2->size);
+  merged_chunk = try_merge(chunk1);
   assert_ptr_equal(merged_chunk, chunk1);
+  printf("**After merge** chunk1->size: %zu\n", chunk1->size);
+  merged_chunk = try_merge(chunk3);
+  assert_ptr_equal(merged_chunk, chunk3); // no free chunks?
+  printf("**After merge** chunk3->size: %zu\n", chunk3->size);
 }

--- a/tests/chunks/tiny_chunk_test.c
+++ b/tests/chunks/tiny_chunk_test.c
@@ -1,33 +1,33 @@
 #include "../../inc/tests.h"
 
-void create_top_tiny_chunk_test(void** state) {
+void tiny_chunk_top_create_test(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_fpage* fpage = pagemap->span_head->fastpages;  fpage->chunk_size = 16;
-  t_tiny_chunk* top_tiny_chunk = create_top_tiny_chunk(fpage);
+  t_tiny_chunk* top_tiny_chunk = tiny_chunk_top_create(fpage);
   assert_int_equal(top_tiny_chunk->size, fpage->chunk_size);
   assert_null(top_tiny_chunk->next);
 }
 
-void create_tiny_chunk_test(void** state) {
+void tiny_chunk_create_test(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_fpage* fpage = pagemap->span_head->fastpages;
   fpage->chunk_size = 16;
   fpage->chunk_count = 0;
-  t_tiny_chunk* tiny_chunk = create_tiny_chunk(fpage);
+  t_tiny_chunk* tiny_chunk = tiny_chunk_create(fpage);
 
   assert_null(tiny_chunk->next);
   assert_int_equal(fpage->chunk_count, 1);
   assert_ptr_equal(fpage->last_chunk, tiny_chunk);
 }
 
-// TODO: waiting on completion of free_tiny_chunk?
-void free_tiny_chunk_test(void** state) {
+// TODO: waiting on completion of tiny_chunk_free?
+void tiny_chunk_free_test(void** state) {
   UNUSED(state);
   // t_pagemap* pagemap = (t_pagemap*)*state;
   // t_fpage* fpage = pagemap->span_head->fastpages;
   // fpage->chunk_size = 16;
   // fpage->chunk_count = 0;
-  // t_tiny_chunk* tiny_chunk = create_tiny_chunk(fpage);
-  // free_tiny_chunk(tiny_chunk, tiny_chunk->size);
+  // t_tiny_chunk* tiny_chunk = tiny_chunk_create(fpage);
+  // tiny_chunk_free(tiny_chunk, tiny_chunk->size);
   // assert_null(tiny_chunk);
 }

--- a/tests/chunks/tiny_chunk_test.c
+++ b/tests/chunks/tiny_chunk_test.c
@@ -1,9 +1,9 @@
 #include "../../inc/tests.h"
 
-void tiny_chunk_top_create_test(void** state) {
+void tiny_chunk_base_create_test(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_fpage* fpage = pagemap->span_head->fastpages;  fpage->chunk_size = 16;
-  t_tiny_chunk* top_tiny_chunk = tiny_chunk_top_create(fpage);
+  t_tiny_chunk* top_tiny_chunk = tiny_chunk_base_create(fpage);
   assert_int_equal(top_tiny_chunk->size, fpage->chunk_size);
   assert_null(top_tiny_chunk->next);
 }

--- a/tests/frontend_cache/cache_table_test.c
+++ b/tests/frontend_cache/cache_table_test.c
@@ -8,16 +8,24 @@ void cache_table_create_test(void** state) {
   assert_int_equal(table->capacity, NUM_BINS);
 }
 
-void cache_table_set_test(void** state) {
-    UNUSED(state);
-//   t_pagemap* pagemap = (t_pagemap*)*state;
-//   t_cache* cache = pagemap->frontend_cache;
+void cache_table_set_and_get_test(void** state) {
+  // create chunks
+  t_pagemap* pagemap = (t_pagemap*)*state;
+  t_cache* table = pagemap->frontend_cache->cache_table;
+  t_chunk* top_chunk = pagemap->top_chunk;
+  t_chunk* chunk1 = chunk_split(top_chunk, 72);
+  top_chunk = pagemap->top_chunk;
+  t_chunk* chunk2 = chunk_split(top_chunk, 100);
+  top_chunk = pagemap->top_chunk;
+  t_chunk* chunk3 = chunk_split(top_chunk, 212);
+  SET_FREE(chunk1);
+  SET_FREE(chunk2);
+  SET_FREE(chunk3);
+
+  // add chunks to cache_table
+  int success;
+  success = cache_table_set(chunk1);
+
 
 }
 
-void cache_table_get_test(void** state) {
-    UNUSED(state);
-//   t_pagemap* pagemap = (t_pagemap*)*state;
-//   t_cache* cache = pagemap->frontend_cache;
-
-}

--- a/tests/frontend_cache/cache_table_test.c
+++ b/tests/frontend_cache/cache_table_test.c
@@ -1,0 +1,23 @@
+#include "../../inc/tests.h"
+
+void cache_table_create_test(void** state) {
+  t_pagemap* pagemap = (t_pagemap*)*state;
+  t_cache* cache = pagemap->frontend_cache;
+  t_cache_table* table = cache_table_create(cache);
+  assert_ptr_not_equal(table, NULL);
+  assert_int_equal(table->capacity, NUM_BINS);
+}
+
+void cache_table_set_test(void** state) {
+    UNUSED(state);
+//   t_pagemap* pagemap = (t_pagemap*)*state;
+//   t_cache* cache = pagemap->frontend_cache;
+
+}
+
+void cache_table_get_test(void** state) {
+    UNUSED(state);
+//   t_pagemap* pagemap = (t_pagemap*)*state;
+//   t_cache* cache = pagemap->frontend_cache;
+
+}

--- a/tests/frontend_cache/cache_table_test.c
+++ b/tests/frontend_cache/cache_table_test.c
@@ -11,7 +11,6 @@ void cache_table_create_test(void** state) {
 void cache_table_set_and_get_test(void** state) {
   // create chunks
   t_pagemap* pagemap = (t_pagemap*)*state;
-  t_cache* table = pagemap->frontend_cache->cache_table;
   t_chunk* top_chunk = pagemap->top_chunk;
   t_chunk* chunk1 = chunk_split(top_chunk, 72);
   top_chunk = pagemap->top_chunk;
@@ -25,7 +24,18 @@ void cache_table_set_and_get_test(void** state) {
   // add chunks to cache_table
   int success;
   success = cache_table_set(chunk1);
+  assert_int_not_equal(success, 1);
+  void* result = cache_table_get(chunk1->size);
+  assert_ptr_equal(result, chunk1);
 
+  success = cache_table_set(chunk2);
+  assert_int_not_equal(success, 1);
+  result = cache_table_get(chunk2->size);
+  assert_ptr_equal(result, chunk2);
 
+  success = cache_table_set(chunk3);
+  assert_int_not_equal(success, 1);
+  result = cache_table_get(chunk3->size);
+  assert_ptr_equal(result, chunk3);
 }
 

--- a/tests/frontend_cache/fast_cache_test.c
+++ b/tests/frontend_cache/fast_cache_test.c
@@ -1,9 +1,9 @@
 #include "../../inc/tests.h"
 
-void create_fast_cache_test(void** state) {
+void fast_cache_create_test(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
   t_cache* cache = pagemap->frontend_cache;
-  t_tiny_chunk** fast_cache = create_fast_cache(cache);
+  t_tiny_chunk** fast_cache = fast_cache_create(cache);
   for (size_t i = 0; i < cache->fcache_size; ++i) {
     assert_null(fast_cache[i]);
   }

--- a/tests/frontend_cache/sorted_cache_test.c
+++ b/tests/frontend_cache/sorted_cache_test.c
@@ -3,34 +3,24 @@
 void search_sorted_cache_test(void** state) {
   UNUSED(state);
   t_pagemap* pagemap = (t_pagemap*)*state;
+
   t_chunk* top_chunk = pagemap->top_chunk;
-  t_chunk* chunk1 = chunk_split(top_chunk, 72);
+  size_t size = round_up_to_next(72);
+  t_chunk* chunk1 = chunk_split(top_chunk, size);
   top_chunk = pagemap->top_chunk;
   SET_FREE(chunk1);
   cache_table_set(chunk1);
-  
   void* result = search_sorted_cache(72, small);
   assert_ptr_not_equal(result, NULL);
-  assert_int_equal((size_t)(result - sizeof(size_t)), 72);
+  t_chunk* result_ck = DATA_TO_CHUNK(result);
+  assert_int_equal(result_ck->size, 88);
 
-  top_chunk = pagemap->top_chunk;
-  t_chunk* chunk2 = chunk_split(top_chunk, 100);
+  size = round_up_to_next(100);
+  t_chunk* chunk2 = chunk_split(top_chunk, size);
   SET_FREE(chunk2);
-  cache_table_set(chunk2);
-
   result = search_sorted_cache(100, small);
   assert_ptr_not_equal(result, NULL);
-  assert_int_equal((size_t)(result - sizeof(size_t)), 100);
-  
-  top_chunk = pagemap->top_chunk;
-  t_chunk* chunk3 = chunk_split(top_chunk, 212);
-  SET_FREE(chunk3);
-  cache_table_set(chunk3);
-
-//   result = search_sorted_cache(200, small);
-//   assert_ptr_not_equal(result, NULL);
-//   assert_int_equal(result, (void*)(chunk3 + pointer_size));
-
+  result_ck = DATA_TO_CHUNK(result);
 }
 
 void search_sorted_cache_null_test(void** state) {

--- a/tests/frontend_cache/sorted_cache_test.c
+++ b/tests/frontend_cache/sorted_cache_test.c
@@ -1,0 +1,41 @@
+#include "../../inc/tests.h"
+
+void search_sorted_cache_test(void** state) {
+  UNUSED(state);
+  t_pagemap* pagemap = (t_pagemap*)*state;
+  t_chunk* top_chunk = pagemap->top_chunk;
+  t_chunk* chunk1 = chunk_split(top_chunk, 72);
+  top_chunk = pagemap->top_chunk;
+  SET_FREE(chunk1);
+  cache_table_set(chunk1);
+  
+  void* result = search_sorted_cache(72, small);
+  assert_ptr_not_equal(result, NULL);
+  assert_int_equal((size_t)(result - sizeof(size_t)), 72);
+
+  top_chunk = pagemap->top_chunk;
+  t_chunk* chunk2 = chunk_split(top_chunk, 100);
+  SET_FREE(chunk2);
+  cache_table_set(chunk2);
+
+  result = search_sorted_cache(100, small);
+  assert_ptr_not_equal(result, NULL);
+  assert_int_equal((size_t)(result - sizeof(size_t)), 100);
+  
+  top_chunk = pagemap->top_chunk;
+  t_chunk* chunk3 = chunk_split(top_chunk, 212);
+  SET_FREE(chunk3);
+  cache_table_set(chunk3);
+
+//   result = search_sorted_cache(200, small);
+//   assert_ptr_not_equal(result, NULL);
+//   assert_int_equal(result, (void*)(chunk3 + pointer_size));
+
+}
+
+void search_sorted_cache_null_test(void** state) {
+  UNUSED(state);
+  size_t size = 100;
+  void* result = search_unsorted_cache(size);
+  assert_null(result);
+}

--- a/tests/frontend_cache/unsorted_cache_test.c
+++ b/tests/frontend_cache/unsorted_cache_test.c
@@ -3,7 +3,7 @@
 void search_unsorted_cache_test(void** state) {
   UNUSED(state);
   size_t size = 100;
-  t_chunk* unsorted_ck = g_pagemap->span_head->page_head->next->top_chunk;
+  t_chunk* unsorted_ck = g_pagemap->span_head->page_head->next->base_chunk;
   // printf("unsorted_ck->size: %zu\n", unsorted_ck->size);
   size_t new_unsorted_size = unsorted_ck->size - size;
   // printf("new_unsorted_size: %zu\n", new_unsorted_size);
@@ -27,7 +27,7 @@ void search_unsorted_cache_null_test(void** state) {
 void search_unsorted_cache_large_test(void** state) {
   UNUSED(state);
   size_t size = 1000;
-  t_chunk* unsorted_ck = g_pagemap->span_head->page_head->next->top_chunk;
+  t_chunk* unsorted_ck = g_pagemap->span_head->page_head->next->base_chunk;
   size_t new_unsorted_size = unsorted_ck->size - size;
   unsorted_ck->fd = g_pagemap->frontend_cache->unsorted_cache;
   g_pagemap->frontend_cache->unsorted_cache = unsorted_ck;

--- a/tests/frontend_cache/unsorted_cache_test.c
+++ b/tests/frontend_cache/unsorted_cache_test.c
@@ -3,15 +3,18 @@
 void search_unsorted_cache_test(void** state) {
   UNUSED(state);
   size_t size = 100;
-  size_t top_chunk_size = CHUNK_SIZE(g_pagemap->top_chunk);
-  free_chunk(g_pagemap->top_chunk, top_chunk_size);
+  t_chunk* unsorted_ck = g_pagemap->span_head->page_head->next->top_chunk;
+  // printf("unsorted_ck->size: %zu\n", unsorted_ck->size);
+  size_t new_unsorted_size = unsorted_ck->size - size;
+  // printf("new_unsorted_size: %zu\n", new_unsorted_size);
+  unsorted_ck->fd = g_pagemap->frontend_cache->unsorted_cache;
+  g_pagemap->frontend_cache->unsorted_cache = unsorted_ck;
+  
+  
   void* result = search_unsorted_cache(size);
 
   assert_ptr_not_equal(result, NULL);
-  assert_int_equal(CHUNK_SIZE(g_pagemap->top_chunk), 0);
-
-  t_chunk* unsorted_chunk = g_pagemap->frontend_cache->unsorted_cache;
-  assert_ptr_equal(unsorted_chunk, NULL);
+  assert_int_equal(new_unsorted_size, g_pagemap->frontend_cache->unsorted_cache->size);
 }
 
 void search_unsorted_cache_null_test(void** state) {
@@ -24,23 +27,17 @@ void search_unsorted_cache_null_test(void** state) {
 void search_unsorted_cache_large_test(void** state) {
   UNUSED(state);
   size_t size = 1000;
-  size_t top_chunk_size = CHUNK_SIZE(g_pagemap->top_chunk);
-  free_chunk(g_pagemap->top_chunk, top_chunk_size);
+  t_chunk* unsorted_ck = g_pagemap->span_head->page_head->next->top_chunk;
+  size_t new_unsorted_size = unsorted_ck->size - size;
+  unsorted_ck->fd = g_pagemap->frontend_cache->unsorted_cache;
+  g_pagemap->frontend_cache->unsorted_cache = unsorted_ck;
+  
+  
   void* result = search_unsorted_cache(size);
-  assert_ptr_not_equal(result, NULL);
 
-  t_chunk* unsorted_chunk = g_pagemap->frontend_cache->unsorted_cache;
-  assert_ptr_equal(unsorted_chunk, NULL);
+  assert_ptr_not_equal(result, NULL);
+  assert_int_equal(new_unsorted_size, g_pagemap->frontend_cache->unsorted_cache->size);
+
 
 }
 
-void search_unsorted_cache_small_test(void** state) {
-  UNUSED(state);
-  size_t size = 16;
-  size_t top_chunk_size = CHUNK_SIZE(g_pagemap->top_chunk);
-  free_chunk(g_pagemap->top_chunk, top_chunk_size);
-  void* result = search_unsorted_cache(size);
-  assert_ptr_not_equal(result, NULL);
-  t_chunk* unsorted_chunk = g_pagemap->frontend_cache->unsorted_cache;
-  assert_ptr_equal(unsorted_chunk, NULL);
-}

--- a/tests/main_test.c
+++ b/tests/main_test.c
@@ -12,7 +12,6 @@ static int setup(void** state) {
 }
 
 static int teardown(void** state) {
-    UNUSED(state);
     destroy_pagemap((t_pagemap*)state);
 
     return 0;
@@ -30,7 +29,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(free_chunk_test, setup, teardown),
         cmocka_unit_test_setup_teardown(free_huge_chunk_test, setup, teardown),
         cmocka_unit_test_setup_teardown(merge_chunks_test, setup, teardown),
-        cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
+        // cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
 
         // =================== Tiny Chunk ===================
         cmocka_unit_test_setup_teardown(create_top_tiny_chunk_test, setup, teardown),
@@ -45,7 +44,11 @@ int main(void) {
         cmocka_unit_test_setup_teardown(search_unsorted_cache_test, setup, teardown),
         cmocka_unit_test_setup_teardown(search_unsorted_cache_null_test, setup, teardown),
         cmocka_unit_test_setup_teardown(search_unsorted_cache_large_test, setup, teardown),
-        cmocka_unit_test_setup_teardown(search_unsorted_cache_small_test, setup, teardown),
+
+        // =================== Cache Table ===================
+        cmocka_unit_test_setup_teardown(cache_table_create_test, setup, teardown),
+        // cmocka_unit_test_setup_teardown(cache_table_set_test, setup, teardown),
+        // cmocka_unit_test_setup_teardown(cache_table_get_test, setup, teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/main_test.c
+++ b/tests/main_test.c
@@ -9,10 +9,10 @@ static int setup(void** state) {
     /* pagemap_create() integrated function path:
     frontend_cache_create() -> fast_cache_create()
     frontend_cache_create() -> cache_table_create()
-    span_base_create() -> pages_create() -> page_base_create() -> chunk_top_create()
-    pages_create() -> page_create() -> chunk_top_create()
-    span_base_create() -> fpages_create() - fpage_base_create() -> tiny_chunk_top_create()
-    fpages_create() - fpage_create() -> tiny_chunk_top_create()
+    span_base_create() -> pages_create() -> page_base_create() -> chunk_base_create()
+    pages_create() -> page_create() -> chunk_base_create()
+    span_base_create() -> fpages_create() - fpage_base_create() -> tiny_chunk_base_create()
+    fpages_create() - fpage_create() -> tiny_chunk_base_create()
     */
 
     *state = g_pagemap;
@@ -29,7 +29,7 @@ static int teardown(void** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         // =================== Chunk ===================
-        cmocka_unit_test_setup_teardown(chunk_top_create_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(chunk_base_create_test, setup, teardown),
         cmocka_unit_test_setup_teardown(chunk_split_test_success, setup, teardown),
         cmocka_unit_test_setup_teardown(huge_chunk_allocate_test_success, setup, teardown),
         cmocka_unit_test_setup_teardown(huge_chunk_allocate_test_failure, setup, teardown),
@@ -39,7 +39,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
 
         // =================== Tiny Chunk ===================
-        cmocka_unit_test_setup_teardown(tiny_chunk_top_create_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(tiny_chunk_base_create_test, setup, teardown),
         cmocka_unit_test_setup_teardown(tiny_chunk_create_test, setup, teardown),
         cmocka_unit_test_setup_teardown(tiny_chunk_free_test, setup, teardown),
 

--- a/tests/main_test.c
+++ b/tests/main_test.c
@@ -5,14 +5,22 @@
 static int setup(void** state) {
     system_settings();
 
-    create_pagemap(&g_pagemap);
+    pagemap_create(&g_pagemap);
+    /* pagemap_create() integrated function path:
+    frontend_cache_create() -> fast_cache_create()
+    frontend_cache_create() -> cache_table_create()
+    span_base_create() -> pages_create() -> page_base_create() -> chunk_top_create()
+    pages_create() -> page_create() -> chunk_top_create()
+    span_base_create() -> fpages_create() - fpage_base_create() -> tiny_chunk_top_create()
+    fpages_create() - fpage_create() -> tiny_chunk_top_create()
+    */
 
     *state = g_pagemap;
     return 0;
 }
 
 static int teardown(void** state) {
-    destroy_pagemap((t_pagemap*)state);
+    pagemap_destroy((t_pagemap*)state);
 
     return 0;
 }
@@ -21,23 +29,23 @@ static int teardown(void** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         // =================== Chunk ===================
-        cmocka_unit_test_setup_teardown(create_top_chunk_test, setup, teardown),
-        cmocka_unit_test_setup_teardown(split_chunk_test_success, setup, teardown),
-        cmocka_unit_test_setup_teardown(split_chunk_test_failure, setup, teardown),
-        cmocka_unit_test_setup_teardown(allocate_huge_chunk_test_success, setup, teardown),
-        cmocka_unit_test_setup_teardown(allocate_huge_chunk_test_failure, setup, teardown),
-        cmocka_unit_test_setup_teardown(free_chunk_test, setup, teardown),
-        cmocka_unit_test_setup_teardown(free_huge_chunk_test, setup, teardown),
-        cmocka_unit_test_setup_teardown(merge_chunks_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(chunk_top_create_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(chunk_split_test_success, setup, teardown),
+        cmocka_unit_test_setup_teardown(chunk_split_test_failure, setup, teardown),
+        cmocka_unit_test_setup_teardown(huge_chunk_allocate_test_success, setup, teardown),
+        cmocka_unit_test_setup_teardown(huge_chunk_allocate_test_failure, setup, teardown),
+        cmocka_unit_test_setup_teardown(chunk_free_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(huge_chunk_free_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(chunk_merge_test, setup, teardown),
         // cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
 
         // =================== Tiny Chunk ===================
-        cmocka_unit_test_setup_teardown(create_top_tiny_chunk_test, setup, teardown),
-        cmocka_unit_test_setup_teardown(create_tiny_chunk_test, setup, teardown),
-        cmocka_unit_test_setup_teardown(free_tiny_chunk_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(tiny_chunk_top_create_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(tiny_chunk_create_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(tiny_chunk_free_test, setup, teardown),
 
         // =================== Fast Cache ===================
-        cmocka_unit_test_setup_teardown(create_fast_cache_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(fast_cache_create_test, setup, teardown),
         cmocka_unit_test_setup_teardown(search_fast_cache_test, setup, teardown),
 
         // =================== Unsorted Cache ===================
@@ -45,10 +53,14 @@ int main(void) {
         cmocka_unit_test_setup_teardown(search_unsorted_cache_null_test, setup, teardown),
         cmocka_unit_test_setup_teardown(search_unsorted_cache_large_test, setup, teardown),
 
+        // =================== Sorted Cache ===================
+        // cmocka_unit_test_setup_teardown(search_sorted_cache_test, setup, teardown),
+        // cmocka_unit_test_setup_teardown(search_sorted_cache_null_test, setup, teardown),
+        // cmocka_unit_test_setup_teardown(search_sorted_cache_large_test, setup, teardown),
+
         // =================== Cache Table ===================
         cmocka_unit_test_setup_teardown(cache_table_create_test, setup, teardown),
-        // cmocka_unit_test_setup_teardown(cache_table_set_test, setup, teardown),
-        // cmocka_unit_test_setup_teardown(cache_table_get_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(cache_table_set_and_get_test, setup, teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/main_test.c
+++ b/tests/main_test.c
@@ -31,13 +31,12 @@ int main(void) {
         // =================== Chunk ===================
         cmocka_unit_test_setup_teardown(chunk_top_create_test, setup, teardown),
         cmocka_unit_test_setup_teardown(chunk_split_test_success, setup, teardown),
-        cmocka_unit_test_setup_teardown(chunk_split_test_failure, setup, teardown),
         cmocka_unit_test_setup_teardown(huge_chunk_allocate_test_success, setup, teardown),
         cmocka_unit_test_setup_teardown(huge_chunk_allocate_test_failure, setup, teardown),
         cmocka_unit_test_setup_teardown(chunk_free_test, setup, teardown),
         cmocka_unit_test_setup_teardown(huge_chunk_free_test, setup, teardown),
         cmocka_unit_test_setup_teardown(chunk_merge_test, setup, teardown),
-        // cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
 
         // =================== Tiny Chunk ===================
         cmocka_unit_test_setup_teardown(tiny_chunk_top_create_test, setup, teardown),

--- a/tests/main_test.c
+++ b/tests/main_test.c
@@ -36,7 +36,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(chunk_free_test, setup, teardown),
         cmocka_unit_test_setup_teardown(huge_chunk_free_test, setup, teardown),
         cmocka_unit_test_setup_teardown(chunk_merge_test, setup, teardown),
-        // cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
 
         // =================== Tiny Chunk ===================
         cmocka_unit_test_setup_teardown(tiny_chunk_top_create_test, setup, teardown),

--- a/tests/main_test.c
+++ b/tests/main_test.c
@@ -36,7 +36,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(chunk_free_test, setup, teardown),
         cmocka_unit_test_setup_teardown(huge_chunk_free_test, setup, teardown),
         cmocka_unit_test_setup_teardown(chunk_merge_test, setup, teardown),
-        cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
+        // cmocka_unit_test_setup_teardown(try_merge_is_in_use_test, setup, teardown),
 
         // =================== Tiny Chunk ===================
         cmocka_unit_test_setup_teardown(tiny_chunk_top_create_test, setup, teardown),
@@ -53,8 +53,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(search_unsorted_cache_large_test, setup, teardown),
 
         // =================== Sorted Cache ===================
-        // cmocka_unit_test_setup_teardown(search_sorted_cache_test, setup, teardown),
-        // cmocka_unit_test_setup_teardown(search_sorted_cache_null_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(search_sorted_cache_test, setup, teardown),
+        cmocka_unit_test_setup_teardown(search_sorted_cache_null_test, setup, teardown),
         // cmocka_unit_test_setup_teardown(search_sorted_cache_large_test, setup, teardown),
 
         // =================== Cache Table ===================


### PR DESCRIPTION
### What was done?

- Fix logic errors in t_chunk macros, chunk_split() and chunk_merge()
- Restructure t_page struct so that it is a header pointing to the first chunk in the page and all t_chunks are contiguous in the heap

### :tophat: Instructions