### PR TITLE
Beki/fix segv chunk

### DIFF
--- a/JSMalloc_diagrams.md
+++ b/JSMalloc_diagrams.md
@@ -118,6 +118,7 @@ The memory allocator operates through multiple layers: the application, the fron
 
 ## Pageheap Diagram
 
+```plaintext
 +-----------------------+
 |[t_pagemap] = p        |
 | p->frontend_cache     |
@@ -147,26 +148,35 @@ The memory allocator operates through multiple layers: the application, the fron
 +-----------------------+
 | [t_span] = s          |
 +-----------------------+
-| first page            |
+| [t_pages] = p         |
+| p->next               |
+| p->base_chunk         |
+| p->mem_size           |
+| ...                   |
++-----------------------+
+| [t_chunk]             |
 |                       |
-|    chunks             |
+|                       |
 +-----------------------+
-+-----------------------+
+```
 
 
 ## Chunk Header Metadata
 
-Each chunk has a header that includes metadata necessary for managing memory. For free chunks, this header includes:
+Each chunk has a header that includes metadata necessary for managing memory. This header includes:
 
 - **Size and Status**: The size of the chunk, including a flag indicating whether it is free or allocated.
-- **Previous Size**: The size of the previous chunk, allowing backward traversal.
+
+For free chunks, the header also includes:
+- **Forward and Backward Pointers**: These pointers are only in use in the unsorted and sorted caches.
+
 
 ### Tracking Adjacent Chunks
 
 JSMalloc uses the following methods to track adjacent chunks:
 
 - **Boundary Tags**: At the end of each chunk, a boundary tag replicates the size of the chunk.
-- **In-Place Headers**: When a chunk is freed, the allocator uses the size and previous size fields to check the status of adjacent chunks.
+- **In-Place Headers**: When a chunk is freed, the allocator uses the size and boundary tags to check the status of adjacent chunks.
 
 ### Example of Adjacent Chunk Tracking
 
@@ -201,105 +211,4 @@ JSMalloc uses the following methods to track adjacent chunks:
 +------------------+
 | Boundary Tag     | <- size of Chunk C
 +------------------+
-```
-
-## Chunk Structure Definition
-
-In this example, we use a single `chunk` struct that includes all necessary fields, simplifying the code and reducing redundancy.
-
-### Chunk Structure Definition
-
-```c
-typedef struct chunk {
-    size_t size;          // Size of the chunk (includes the size of the header)
-    size_t prev_size;     // Size of the previous chunk
-    struct chunk* fd;     // Forward pointer for the free list
-    struct chunk* bk;     // Backward pointer for the free list
-} chunk;
-
-// Helper macros to access boundary tags
-#define CHUNK_SIZE(chunk) ((chunk)->size & ~0x7) // Mask out lower bits used for status
-#define NEXT_CHUNK(chunk) ((chunk*)((char*)(chunk) + CHUNK_SIZE(chunk)))
-#define PREV_CHUNK(chunk) ((chunk*)((char*)(chunk) - (chunk)->prev_size))
-
-// Alignment to ensure proper boundaries
-#define ALIGN_SIZE 8
-#define ALIGN_MASK (ALIGN_SIZE - 1)
-#define ALIGN(n) (((n) + ALIGN_MASK) & ~ALIGN_MASK)
-
-#define CHUNK_OVERHEAD sizeof(size_t) // Simplified, normally includes additional metadata
-#define MIN_CHUNK_SIZE (sizeof(chunk) + CHUNK_OVERHEAD)
-```
-
-## Functions to Write Boundary Tag and Free Chunks
-
-Next, we implement the functions to free a chunk, write a boundary tag, and coalesce adjacent free chunks.
-
-### Function to Write Boundary Tag
-
-```c
-void chunk_write_boundary_tag(chunk* ch) {
-    size_t* boundary_tag = (size_t*)((char*)ch + CHUNK_SIZE(ch) - sizeof(size_t));
-    *boundary_tag = ch->size;
-}
-```
-
-### Function to Free a Chunk and Coalesce if Possible
-
-```c
-void chunk_free(chunk* ch) {
-    chunk* next_chunk = NEXT_CHUNK(ch);
-
-    // Coalesce with next chunk if it's free
-    if (!(next_chunk->size & 1)) { // Check if next chunk is free
-        ch->size += CHUNK_SIZE(next_chunk);
-        next_chunk = NEXT_CHUNK(ch);
-    }
-
-    // Write the boundary tag
-    chunk_write_boundary_tag(ch);
-
-    // Coalesce with previous chunk if it's free
-    if (!(ch->prev_size & 1)) { // Check if previous chunk is free
-        chunk* prev_chunk = PREV_CHUNK(ch);
-        prev_chunk->size += CHUNK_SIZE(ch);
-        ch = prev_chunk;
-
-        // Write the boundary tag
-        chunk_write_boundary_tag(ch);
-    }
-
-    // Insert chunk into the free list (simplified for this example)
-    ch->fd = free_list;
-    if (free_list) {
-        free_list->bk = ch;
-    }
-    free_list = ch;
-}
-
-// Simplified global free list for demonstration purposes
-chunk* free_list = NULL;
-```
-
-### Usage Example
-
-Here's how you might use these functions in a simple program:
-
-```c
-int main() {
-    // Simulate allocation of a chunk (simplified)
-    size_t chunk_size = ALIGN(100); // Requested size
-    chunk* ch = (chunk*)malloc(chunk_size + sizeof(chunk));
-    ch->size = chunk_size | 1; // Mark as allocated
-    ch->prev_size = 0; // No previous chunk in this example
-
-    // Simulate freeing the chunk
-    ch->size &= ~1; // Mark as free
-    chunk_free(ch);
-
-    // For demonstration purposes, print the size
-```
-
-```
-
 ```

--- a/JsMalloc.md
+++ b/JsMalloc.md
@@ -2,30 +2,31 @@
 
 ### Motivation
 
-JSMalloc introduces a two-tiered dynamic memory allocation system to address various challenges in modern computing environments:
+JSMalloc is a two-tiered dynamic memory allocation system:
 
-- **Enhanced Scalability:** By segregating memory management into backend pageheap and frontend cache, JSMalloc can better handle concurrent memory access in multi-threaded applications.
 - **Efficient Memory Utilization:** Utilizing different page sizes and chunk categorizations allows for optimal memory utilization across various object sizes.
-- **Flexible Resource Management:** JSMalloc can efficiently manage memory resources by dynamically adjusting cache sizes and employing different allocation strategies based on object size.
+- **Flexible Resource Management:** JSMalloc can efficiently manage memory resources by dynamically adjusting cache sizes and employing different allocation strategies based on object size. STATUS: dynamic adjustment of cache sizes will be implemented in a future iteration.
+- **Enhanced Scalability:** By segregating memory management into backend pageheap and frontend cache, JSMalloc will better handle concurrent memory access in multi-threaded applications. STATUS: Handling of multi-threaded applications will be implemented in future iterations.
 
 ### Overview
 
 JSMalloc comprises two main components:
 
-1. **Backend Pageheap:** Manages memory allocation at the page level and interacts with the operating system for memory allocation and deallocation.
-2. **Frontend Cache:** Provides fast allocation and deallocation operations for small and medium-sized objects, reducing contention and improving performance.
+1. **Backend Pageheap:** Manages memory allocation at the page level and interacts with the operating system for memory allocation and deallocation. STATUS: structure and framework there, functionality incomplete.
+2. **Frontend Cache:** Provides fast allocation and deallocation operations for small and medium-sized objects, using a variety of search algorithms and caching structures.
 
 ### JSMalloc Backend Pageheap
 
 - **Span Organization:** Memory is organized into spans, representing isolated heaps of memory allocated from the operating system using the mmap() system call.
-- **Page Management:** Spans are further divided into pages, with each page representing a contiguous block of memory of a fixed size determined by the operating system.
+- **Page Management:** Spans are further divided into pages, with each page representing a contiguous block of memory of a fixed size.
 - **Pagemap Structure:** The pagemap structure facilitates efficient mapping of memory addresses to pages, enabling fast retrieval and management of memory resources.
 
 ### JSMalloc Frontend Cache
 
 - **Tiered Allocation:** Objects are categorized into different size classes based on their size, with separate handling mechanisms for tiny, small, and large objects.
-- **Per-Thread or Per-CPU Caching:** The frontend cache can operate in per-thread mode, where each thread has its local cache, or per-CPU mode, where each logical CPU has its cache, improving efficiency and scalability in multi-threaded environments.
-- **Dynamic Page Movement:** Pages are moved between the backend pageheap and frontend cache based on usage patterns, ensuring efficient utilization of memory resources.
+- **Fast Cache:** Provides fast allocation and deallocation operations for tiny allocation sizes by creating predefined memory blocks where all chunks are of the same size and accessed via a simple array of linked lists. 
+- **Unsorted Cache:** This cache has a singly linked list of recently freed chunks. Chunks are dynamically sorted into the Sorted Cache during the search algo for the Unsorted Cache.  
+- **Sorted Cache:** A hash table with bins for various chunk sizes, each hash points to the head of a doubly linked list of chunks of the same size or similar size once we enter the larger object sizes. STATUS: A future imporvement will be implement the hash table so that the memory for the bins is allocated dynamically. Currently we have a fixed section allocating enough space for all possible bins.
 
 ### Memory Chunk Categorization
 
@@ -38,6 +39,3 @@ JSMalloc comprises two main components:
 - Objects larger than 4KB are allocated directly from the operating system using the mmap() system call, bypassing the frontend cache and backend pageheap.
 - This approach ensures efficient allocation and deallocation of very large memory blocks without incurring the overhead of cache management.
 
-### Conclusion
-
-JSMalloc's two-tiered dynamic allocator provides a robust and efficient solution for memory management in modern computing environments. By combining backend pageheap and frontend cache mechanisms, JSMalloc achieves optimal memory utilization, scalability, and performance for diverse application workloads.

--- a/inc/constants.h
+++ b/inc/constants.h
@@ -17,6 +17,11 @@ extern t_pagemap* g_pagemap;
 #define LARGE_PAGE_ALLOCATION_SIZE 0
 // #define LARGE_MAX_CHUNK_SIZE (LARGE_PAGE_ALLOCATION_SIZE * PAGE_SIZE / 12)
 
+#define TINY_CHUNK_OVERHEAD sizeof(size_t)
+#define CHUNK_OVERHEAD (sizeof(size_t) * 2)
+#define DATA_TO_CHUNK(ptr) ((t_chunk*)((char*)(ptr) - sizeof(size_t)))
+#define CHUNK_TO_DATA(chunk) (void*)((char *)(chunk) + sizeof(size_t))
+
 // Helper macros to set and check t_chunk status
 #define SET_IN_USE(t_chunk) ((t_chunk)->size |= 0x1)
 #define IS_IN_USE(t_chunk) ((t_chunk)->size & 0x1)
@@ -25,15 +30,11 @@ extern t_pagemap* g_pagemap;
 // Helper macros to set and check t_chunk size
 #define SIZE_MASK (~0x1)  // Mask with all bits set except the least significant bit
 #define CHUNK_SIZE(chunk) ((chunk)->size & SIZE_MASK) // Mask out least significant bit
-#define DATA_TO_CHUNK(ptr) ((t_chunk*)((char*)(ptr) - sizeof(size_t)))
-#define CHUNK_TO_DATA(chunk) (void*)((char *)(chunk) + sizeof(size_t))
 
 // Helper macros to access boundary tags
-#define CHUNK_OVERHEAD (sizeof(size_t) * 2)
 #define NEXT_CHUNK(chunk) ((t_chunk*)((char*)(chunk) + CHUNK_SIZE(chunk)))
 #define PREV_SIZE(chunk) (*(size_t*)((char*)(chunk) - sizeof(size_t)))
 #define PREV_CHUNK(chunk, prev_size) ((t_chunk*)((char*)(chunk) - prev_size))
-#define TINY_CHUNK_OVERHEAD sizeof(size_t)
 
 // Helper macros for cache_table
 #define FNV_OFFSET 14695981039346656037UL

--- a/inc/constants.h
+++ b/inc/constants.h
@@ -15,7 +15,7 @@ extern t_pagemap* g_pagemap;
 #define SMALL_PAGE_ALLOCATION_SIZE 40
 #define SMALL_MAX_CHUNK_SIZE 512
 #define LARGE_PAGE_ALLOCATION_SIZE 0
-// #define LARGE_MAX_CHUNK_SIZE (LARGE_PAGE_ALLOCATION_SIZE * PAGE_SIZE / 12)
+#define LARGE_MAX_CHUNK_SIZE (PAGE_SIZE / 2)
 
 #define TINY_CHUNK_OVERHEAD sizeof(size_t)
 #define CHUNK_OVERHEAD (sizeof(size_t) * 2)

--- a/inc/constants.h
+++ b/inc/constants.h
@@ -12,10 +12,10 @@ extern t_pagemap* g_pagemap;
 #define FAST_PAGE_ALLOCATION_SIZE 8
 #define FAST_PAGE_MAX_CHUNK_SIZE 64
 #define FAST_MAX_CHUNK_SIZE 64
-#define SMALL_PAGE_ALLOCATION_SIZE 20
+#define SMALL_PAGE_ALLOCATION_SIZE 40
 #define SMALL_MAX_CHUNK_SIZE 512
-#define LARGE_PAGE_ALLOCATION_SIZE 20
-#define LARGE_MAX_CHUNK_SIZE (LARGE_PAGE_ALLOCATION_SIZE * PAGE_SIZE / 12)
+#define LARGE_PAGE_ALLOCATION_SIZE 0
+// #define LARGE_MAX_CHUNK_SIZE (LARGE_PAGE_ALLOCATION_SIZE * PAGE_SIZE / 12)
 
 // Helper macros to set and check t_chunk status
 #define SET_IN_USE(t_chunk) ((t_chunk)->size |= 0x1)

--- a/src/backend_heap/page.c
+++ b/src/backend_heap/page.c
@@ -11,7 +11,7 @@ void pages_create(t_pagemap* pagemap, t_span* span) {
 
   while (pages_left > 0) {
     temp = current;
-    current = page_create(current, small);
+    current = page_create(temp, small);
     temp->next = current;
     pages_left -= 1;
   }
@@ -19,7 +19,7 @@ void pages_create(t_pagemap* pagemap, t_span* span) {
   pages_left = LARGE_PAGE_ALLOCATION_SIZE;
   while (pages_left > 0) {
     temp = current;
-    current = page_create(current, large);
+    current = page_create(temp, large);
     temp->next = current;
     pages_left -= 1;
   }
@@ -41,11 +41,11 @@ t_page* page_base_create(t_pagemap* pagemap, t_span* span) {
     page->mem_size = PAGE_SIZE - sizeof(t_span) - sizeof(t_page);
   }
   
-  void* start = (void*)PAGE_SHIFT(page);
-  // printf("start: %p\n", start);
+  void* start = (void*)MEMORY_SHIFT(page, (sizeof(t_page) * SMALL_PAGE_ALLOCATION_SIZE));
   page->base_chunk = chunk_base_create(start, page->mem_size);
-  // printf("base_chunk\n\tmem_size: %zu\n\tstart: %p\n\tend: %p\n", page->base_chunk->size,
-  //     page->base_chunk, (char*)(page->base_chunk) + page->base_chunk->size);
+  pagemap->top_chunk = page->base_chunk;
+  // printf("top_chunk\n\tCHUNK_SIZE(chunk): %zu\n\tsize: %zu\n\tstart: %p\n\tend: %p\n", CHUNK_SIZE(pagemap->top_chunk),
+      // pagemap->top_chunk->size, pagemap->top_chunk, (char*)(page->base_chunk) + page->base_chunk->size);
 
   return page;
 }
@@ -58,8 +58,6 @@ t_page* page_create(t_page* prev_page, int pagetype) {
   page->mem_size = PAGE_SIZE - sizeof(t_page);
   page->pagetype = pagetype;
   page->base_chunk = chunk_base_create(start, page->mem_size);
-  // printf("base_chunk\n\tmem_size: %zu\n\tstart: %p\n\tend: %p\n", page->base_chunk->size,
-  //     page->base_chunk, (char*)(page->base_chunk) + page->base_chunk->size);
-
+  // printf("t_page struct\n\tstart: %p\n\tend: %p\n", page, (char*)page + sizeof(t_page));
   return page;
 }

--- a/src/backend_heap/page.c
+++ b/src/backend_heap/page.c
@@ -40,8 +40,12 @@ t_page* page_base_create(t_pagemap* pagemap, t_span* span) {
   else {
     page->mem_size = PAGE_SIZE - sizeof(t_span) - sizeof(t_page);
   }
-
-  page->base_chunk = chunk_base_create((void*)page, page->mem_size);
+  
+  void* start = (void*)PAGE_SHIFT(page);
+  // printf("start: %p\n", start);
+  page->base_chunk = chunk_base_create(start, page->mem_size);
+  // printf("base_chunk\n\tmem_size: %zu\n\tstart: %p\n\tend: %p\n", page->base_chunk->size,
+  //     page->base_chunk, (char*)(page->base_chunk) + page->base_chunk->size);
 
   return page;
 }
@@ -54,6 +58,8 @@ t_page* page_create(t_page* prev_page, int pagetype) {
   page->mem_size = PAGE_SIZE - sizeof(t_page);
   page->pagetype = pagetype;
   page->base_chunk = chunk_base_create(start, page->mem_size);
+  // printf("base_chunk\n\tmem_size: %zu\n\tstart: %p\n\tend: %p\n", page->base_chunk->size,
+  //     page->base_chunk, (char*)(page->base_chunk) + page->base_chunk->size);
 
   return page;
 }

--- a/src/chunks/chunk.c
+++ b/src/chunks/chunk.c
@@ -35,13 +35,11 @@ t_chunk* chunk_split(t_chunk* chunk, size_t size) {
 
     if (g_pagemap->top_chunk == chunk) flag = 1;
 
-    printf("chunk->size: %zu\n", chunk->size);
     // Update the original chunk's size, free status, next pointer & boundary_tag
     t_chunk* first_chunk = chunk;
     first_chunk->size = size;
     first_chunk->fd = NULL;
     first_chunk->bk = NULL;
-    printf("first_chunk->size: %zu\n", first_chunk->size);
     chunk_write_boundary_tag(first_chunk);
     SET_IN_USE(first_chunk);    // set in_use after writing boundary tag 
 
@@ -50,8 +48,6 @@ t_chunk* chunk_split(t_chunk* chunk, size_t size) {
     second_chunk->size = initial_chunk_size - size;
     second_chunk->bk = NULL;
     second_chunk->fd = NULL;
-    printf("second_chunk->size: %zu\n", second_chunk->size);
-    printf("now here\n");
     chunk_write_boundary_tag(second_chunk);
 
     if (flag == 1) g_pagemap->top_chunk = second_chunk;

--- a/tests/chunks/chunk_test.c
+++ b/tests/chunks/chunk_test.c
@@ -15,11 +15,11 @@ void chunk_base_create_test(void** state) {
 
 void chunk_split_test_success(void** state) {
   t_pagemap* pagemap = (t_pagemap*)*state;
-
-  size_t new_top_size = pagemap->top_chunk->size - 100;
-  t_chunk* split = chunk_split(pagemap->top_chunk, 100);
+  t_chunk* ck = pagemap->top_chunk;
+  size_t new_top_size = ck->size - 100;
+  t_chunk* split = chunk_split(ck, 100);
   assert_int_equal(CHUNK_SIZE(split), 100);
-  assert_int_equal(pagemap->top_chunk->fd, split->fd);
+  assert_int_equal(ck->fd, split->fd);
   assert_int_equal(split->fd, NULL);
   assert_int_equal(split->bk, NULL);
   assert_int_equal(new_top_size, pagemap->top_chunk->size);


### PR DESCRIPTION
### What was done?

Fixed regression caused by grouping of t_page headers and t_chunks in previous PR:
- unfortunately our CI/CD did not catch this regression at the time of the PR
- the SEGV was by caused by an incorrect memory_shift between the start of the first t_page header and the start of the first base_chunk (not enough memory was allocated) therefore the t_chunk was being written over and causing a SEGV

Updated doc pages:
- edited JSmalloc.md and JSmalloc-diagrams.md to more accurately reflect our project's current structure.

### :tophat: Instructions